### PR TITLE
Fix data override mixin into vue component only

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -23,7 +23,7 @@ export function mount<P>(
   originalComponent: any,
   options?: MountingOptions<P>
 ): VueWrapper {
-  let component = { ...originalComponent }
+  const component = { ...originalComponent }
 
   // Reset the document.body
   document.getElementsByTagName('html')[0].innerHTML = ''


### PR DESCRIPTION
I tried to scope the mixin to be only in the Vue component's mixin and it works. I am not sure if thats the best way though. 

Other way would be as @lmiller1990 suggested, to put a check inside the global mixin for if the current instance is the one that is being mounted. But I dont know what to check against.

VTU beta uses I think this approach, but I think `extend` is no longer available
```js
  const Constructor = _Vue.extend(componentOptions).extend(instanceOptions)
```
