### PR TITLE
Move global app properties, fix #28

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -137,8 +137,10 @@ mount(Component, {
   }
 })
 ```
-
-### `mixins`
+### Global
+You can provide properties to the App instance using the properties under the `global` mount property
+ 
+### `global.mixins`
 
 Applies mixins via `app.mixin(...)`.
 
@@ -161,14 +163,16 @@ test('adds a lifecycle mixin', () => {
   }
 
   const wrapper = mount(Component, {
-    mixins: [mixin]
+    global: {
+      mixins: [mixin]
+    }
   })
 
   // 'Component was created!' will be logged
 })
 ```
 
-### `plugins`
+### `global.plugins`
 
 Installs plugins on the component.
 
@@ -194,7 +198,9 @@ test('installs a plugin via `plugins`', () => {
     render() { return h('div') }
   }
   mount(Component, {
-    plugins: [Plugin]
+    global: {
+      plugins: [Plugin]
+    }
   })
 
   expect(installed).toHaveBeenCalled()

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,4 +1,11 @@
-import { h, createApp, VNode, defineComponent } from 'vue'
+import {
+  h,
+  createApp,
+  VNode,
+  defineComponent,
+  Plugin,
+  ComponentOptions
+} from 'vue'
 
 import { VueWrapper, createWrapper } from './vue-wrapper'
 import { createEmitMixin } from './emitMixin'
@@ -13,8 +20,10 @@ interface MountingOptions<Props> {
     default?: Slot
     [key: string]: Slot
   }
-  plugins?: any[]
-  mixins?: any[]
+  global?: {
+    plugins?: Plugin[]
+    mixins?: ComponentOptions[]
+  }
   provides?: Record<any, any>
   stubs?: Record<string, any>
 }
@@ -59,13 +68,13 @@ export function mount<P>(
   const vm = createApp(Parent(options && options.props))
 
   // use and plugins from mounting options
-  if (options?.plugins) {
-    for (const use of options.plugins) vm.use(use)
+  if (options?.global?.plugins) {
+    for (const use of options?.global?.plugins) vm.use(use)
   }
 
   // use any mixins from mounting options
-  if (options?.mixins) {
-    for (const mixin of options.mixins) vm.mixin(mixin)
+  if (options?.global?.mixins) {
+    for (const mixin of options?.global?.mixins) vm.mixin(mixin)
   }
 
   // provide any values passed via provides mounting option

--- a/tests/mountingOptions/mixins.spec.ts
+++ b/tests/mountingOptions/mixins.spec.ts
@@ -11,11 +11,15 @@ describe('mounting options: mixins', () => {
       }
     }
     const Component = {
-      render() { return h('div') }
+      render() {
+        return h('div')
+      }
     }
 
     mount(Component, {
-      mixins: [mixin]
+      global: {
+        mixins: [mixin]
+      }
     })
 
     expect(createdHook).toHaveBeenCalled()

--- a/tests/mountingOptions/plugins.spec.ts
+++ b/tests/mountingOptions/plugins.spec.ts
@@ -5,16 +5,22 @@ import { mount } from '../../src'
 describe('mounting options: plugins', () => {
   it('installs a plugin via `plugins`', () => {
     const installed = jest.fn()
+
     class Plugin {
       static install() {
         installed()
       }
     }
+
     const Component = {
-      render() { return h('div') }
+      render() {
+        return h('div')
+      }
     }
     mount(Component, {
-      plugins: [Plugin]
+      global: {
+        plugins: [Plugin]
+      }
     })
 
     expect(installed).toHaveBeenCalled()


### PR DESCRIPTION
Moves App instance properties to `global` mount option
Closes #28 