### PR TITLE
refactor: provides -> provide and move to global property

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -25,8 +25,8 @@ interface MountingOptions<Props> {
   global?: {
     plugins?: Plugin[]
     mixins?: ComponentOptions[]
+    provide?: Record<any, any>
   }
-  provides?: Record<any, any>
   stubs?: Record<string, any>
 }
 
@@ -77,10 +77,10 @@ export function mount<P>(
   }
 
   // provide any values passed via provides mounting option
-  if (options?.provides) {
-    for (const key of Reflect.ownKeys(options.provides)) {
+  if (options?.global?.provide) {
+    for (const key of Reflect.ownKeys(options.global.provide)) {
       // @ts-ignore: https://github.com/microsoft/TypeScript/issues/1863
-      vm.provide(key, options.provides[key])
+      vm.provide(key, options.global.provide[key])
     }
   }
 

--- a/tests/mountingOptions/provides.spec.ts
+++ b/tests/mountingOptions/provides.spec.ts
@@ -13,8 +13,10 @@ describe('mounting options: provides', () => {
     }
 
     const wrapper = mount(Component, {
-      provides: { 
-        [GreetingSymbol]: 'Provided value'
+      global: {
+        provide: {
+          [GreetingSymbol]: 'Provided value'
+        }
       }
     })
 


### PR DESCRIPTION
resolves #27 

- provides -> provide to match Vue API more closely
- move to newly added `global` property