### PR TITLE
WIP: basic searching for nested component instances

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,0 +1,42 @@
+import { VNode } from 'vue/dist/vue'
+
+function matches(node: VNode, selector): boolean {
+  if (typeof selector === 'string') {
+    return node.el?.matches?.(selector)
+  }
+  if (typeof selector === 'object') {
+    if (selector.name && typeof node.type === 'object') {
+      // @ts-ignore
+      return node.type.name === selector.name
+    }
+  }
+  return false
+}
+
+function aggregateChildren(nodes, children) {
+  if (children && Array.isArray(children)) {
+    ;[...children].reverse().forEach((n: VNode) => {
+      nodes.unshift(n)
+    })
+  }
+}
+
+function findAllVNodes(vnode: VNode, selector: any) {
+  const matchingNodes = []
+  const nodes = [vnode]
+  while (nodes.length) {
+    const node = nodes.shift()
+    aggregateChildren(nodes, node.children)
+    aggregateChildren(nodes, node.component?.subTree.children)
+    if (matches(node, selector)) {
+      matchingNodes.push(node)
+    }
+  }
+
+  return matchingNodes
+}
+
+export function find(root: VNode, selector: any) {
+  const result = findAllVNodes(root, selector)
+  return result.length ? result[0] : undefined
+}

--- a/src/vue-wrapper.ts
+++ b/src/vue-wrapper.ts
@@ -1,10 +1,11 @@
-import { ComponentPublicInstance } from 'vue'
+import { ComponentPublicInstance, VNode } from 'vue'
 import { ShapeFlags } from '@vue/shared'
 
 import { DOMWrapper } from './dom-wrapper'
 import { WrapperAPI } from './types'
 import { ErrorWrapper } from './error-wrapper'
 import { MOUNT_ELEMENT_ID } from './constants'
+import { find } from './utils/find'
 
 export class VueWrapper implements WrapperAPI {
   rootVM: ComponentPublicInstance
@@ -69,6 +70,13 @@ export class VueWrapper implements WrapperAPI {
     }
 
     return new ErrorWrapper({ selector })
+  }
+
+  findByComponent(selector: { ref?: string; name?: string } | string): any {
+    if (typeof selector === 'object' && selector.ref) {
+      return this.componentVM.$refs[selector.ref]
+    }
+    return find(this.componentVM.$.subTree, selector)
   }
 
   findAll<T extends Element>(selector: string): DOMWrapper<T>[] {

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -2,6 +2,7 @@ import { defineComponent, h } from 'vue'
 
 import { mount } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
+import Hello from './components/Hello.vue'
 
 describe('find', () => {
   it('find using single root node', () => {
@@ -42,6 +43,28 @@ describe('find', () => {
 
     expect(wrapper.html()).toContain('Fallback content')
     expect(wrapper.find('div').exists()).toBeTruthy()
+  })
+
+  it('finds deeply nested vue components', () => {
+    const compC = {
+      template: '<div class="C">C</div>'
+    }
+    const compB = {
+      template: '<div class="B">TextBefore<comp-c/>TextAfter<comp-c/></div>',
+      components: { compC }
+    }
+    const compA = {
+      template: '<div class="A"><comp-b/><hello ref="b"/></div>',
+      components: { compB, Hello }
+    }
+    const wrapper = mount(compA)
+    // find by ref
+    expect(wrapper.findByComponent({ ref: 'b' })).toBeTruthy()
+    // find by DOM selector
+    expect(wrapper.findByComponent('.C').el.textContent).toEqual('C')
+    expect(wrapper.findByComponent({ name: 'Hello' }).el.textContent).toBe(
+      'Hello world'
+    )
   })
 })
 


### PR DESCRIPTION
Allows finding Vue Instances or Element nodes. This is just a POC, but you get the idea.

Its a new method for easier typing. As I said I know nothing about TS so thats easiest for me.
It currently returns either a public instance or a VNode, but thats details 😆 
I could not return VueWrapper or DOMWrapper as the way we VueWrapper instantiated atm, and did not want to touch too much.
Also Lachlan's refactoring of methods using 'appRootNode' will fail here.
This will ofc not allow you to find the component you are currently mounting, something we enabled some days ago.

Thats all from me for today :)

```js
// find by ref
expect(wrapper.findByComponent({ ref: 'b' })): ComponentPublicInstance
// find by DOM selector
expect(wrapper.findByComponent('.C')): VNode // can be Vue Component or Normal DOM node
// find by name
expect(wrapper.findByComponent({ name: 'Hello' }): VNode // Only Vue Component
```