### PR TITLE
Mark isVisible as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ setProps | ✅ |
 setData | ❌ | has PR
 destroy | ❌
 get | ❌
-isVisible | ❌ | use matchers such as [this](https://github.com/testing-library/jest-dom#tobeempty)
 props | ❌
 contains | ⚰️| use `find` 
 emittedByOrder | ⚰️ | use `emitted`
@@ -95,6 +94,7 @@ setSelected | ⚰️ | now part of `setValue`
 setChecked | ⚰️| now part of `setValue` 
 is | ⚰️ 
 isEmpty | ⚰️ | use matchers such as [this](https://github.com/testing-library/jest-dom#tobeempty)
+isVisible | ⚰️ | use matchers such as [this](https://github.com/testing-library/jest-dom#tobevisible)
 isVueInstance | ⚰️ 
 name | ⚰️ |
 setMethods | ⚰️ | 


### PR DESCRIPTION
AFAIK (https://github.com/vuejs/vue-test-utils-next/issues/17) `isVisible` is deprecated, while in the repo's README it is marked as "will be implemented".