### PR TITLE
feat: Add createStubs plugin hook

### DIFF
--- a/docs/guide/extending-vtu/plugins.md
+++ b/docs/guide/extending-vtu/plugins.md
@@ -10,7 +10,9 @@ Some use cases for plugins:
 1.  Attaching matchers to the Wrapper instance
 1.  Attaching functionality to the Wrapper
 
-## Using a Plugin
+## Wrapper Plugin
+
+### Using a Plugin
 
 Install plugins by calling the `config.plugins.VueWrapper.install()` method
 . This has to be done before you call `mount`.
@@ -43,12 +45,12 @@ once. Follow the instructions of the plugin you're installing.
 
 Check out the [Vue Community Guide](https://vue-community.org/v2/guide/ecosystem/testing.html) or [awesome-vue](https://github.com/vuejs/awesome-vue#test) for a collection of community-contributed plugins and libraries.
 
-## Writing a Plugin
+### Writing a Plugin
 
 A Vue Test Utils plugin is simply a function that receives the mounted
 `VueWrapper` or `DOMWrapper` instance and can modify it.
 
-### Basic Plugin
+#### Basic Plugin
 
 Below is a simple plugin to add a convenient alias to map `wrapper.element` to `wrapper.$el`
 
@@ -75,7 +77,7 @@ const wrapper = mount({ template: `<h1>🔌 Plugin</h1>` })
 console.log(wrapper.$el.innerHTML) // 🔌 Plugin
 ```
 
-### Data Test ID Plugin
+#### Data Test ID Plugin
 
 The below plugin adds a method `findByTestId` to the `VueWrapper` instance. This encourages using a selector strategy relying on test-only attributes on your Vue Components.
 
@@ -120,6 +122,50 @@ const DataTestIdPlugin = (wrapper) => {
 }
 
 config.plugins.VueWrapper.install(DataTestIdPlugin)
+```
+
+## Stubs Plugin
+
+The `config.plugins.createStubs` allows to overwrite the default stub creation provided by VTU.
+
+Some use cases are:
+* You want to add more logic into the stubs (for example named slots)
+* You want to use different stubs for multiple components (for example stub components from a library)
+
+### Usage
+
+```typescript
+config.plugins.createStubs = ({ name, component }) => {
+  return defineComponent({
+    render: () => h(`custom-${name}-stub`)
+  })
+}
+```
+
+This function will be called everytime VTU generates a stub either from
+```typescript
+const wrapper = mount(Component, {
+  global: {
+    stubs: {
+      ChildComponent: true
+    }
+  }
+})
+```
+or 
+```typescript
+const wrapper = shallowMount(Component)
+```
+
+But will not be called, when you explicit set a stub
+```typescript
+const wrapper = mount(Component, {
+  global: {
+    stubs: {
+      ChildComponent: { template: '<child-stub/>' }
+    }
+  }
+})
 ```
 
 ## Featuring Your Plugin

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,12 +1,14 @@
 import { GlobalMountOptions } from './types'
 import { VueWrapper } from './vueWrapper'
 import { DOMWrapper } from './domWrapper'
+import { CustomCreateStub } from './stubs'
 
 export interface GlobalConfigOptions {
   global: Required<GlobalMountOptions>
   plugins: {
     VueWrapper: Pluggable<VueWrapper>
     DOMWrapper: Pluggable<DOMWrapper<Node>>
+    createStubs?: CustomCreateStub
   }
   renderStubDefaultSlot: boolean
 }

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -20,6 +20,12 @@ import {
   getComponentName,
   getComponentRegisteredName
 } from './utils/componentName'
+import { config } from './config'
+
+export type CustomCreateStub = (params: {
+  name: string
+  component: ConcreteComponent
+}) => ConcreteComponent
 
 interface StubOptions {
   name: string
@@ -259,11 +265,16 @@ export function stubComponents(
         }
 
         const newStub = createStubOnce(type, () =>
-          createStub({
-            name: stubName,
-            type,
-            renderStubDefaultSlot
-          })
+          config.plugins.createStubs
+            ? config.plugins.createStubs({
+                name: stubName,
+                component: type
+              })
+            : createStub({
+                name: stubName,
+                type,
+                renderStubDefaultSlot
+              })
         )
         registerStub({ source: type, stub: newStub })
         return [newStub, props, children, patchFlag, dynamicProps]

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -104,11 +104,7 @@ describe('createStubs', () => {
   }
 
   const Parent = {
-    render: () => h('div', [
-      h(Child1),
-      h(Child1),
-      h(Child2)
-    ])
+    render: () => h('div', [h(Child1), h(Child1), h(Child2)])
   }
 
   const customCreateStub = jest.fn(({ name }) => h(`${name}-custom-stub`))
@@ -129,15 +125,23 @@ describe('createStubs', () => {
       shallow: true
     })
 
-    expect(wrapper.html()).toBe('<div>\n' +
-      '  <child1-custom-stub></child1-custom-stub>\n' +
-      '  <child1-custom-stub></child1-custom-stub>\n' +
-      '  <child2-custom-stub></child2-custom-stub>\n' +
-      '</div>')
+    expect(wrapper.html()).toBe(
+      '<div>\n' +
+        '  <child1-custom-stub></child1-custom-stub>\n' +
+        '  <child1-custom-stub></child1-custom-stub>\n' +
+        '  <child2-custom-stub></child2-custom-stub>\n' +
+        '</div>'
+    )
 
     expect(customCreateStub).toHaveBeenCalledTimes(2)
-    expect(customCreateStub).toHaveBeenCalledWith({ name: 'child1', component: Child1 })
-    expect(customCreateStub).toHaveBeenCalledWith({ name: 'child2', component: Child2 })
+    expect(customCreateStub).toHaveBeenCalledWith({
+      name: 'child1',
+      component: Child1
+    })
+    expect(customCreateStub).toHaveBeenCalledWith({
+      name: 'child2',
+      component: Child2
+    })
   })
 
   it('should be called only for stubbed components', () => {
@@ -149,24 +153,31 @@ describe('createStubs', () => {
       }
     })
 
-    expect(wrapper.html()).toBe('<div>\n' +
-      '  <div>real child 1</div>\n' +
-      '  <div>real child 1</div>\n' +
-      '  <child2-custom-stub></child2-custom-stub>\n' +
-      '</div>')
+    expect(wrapper.html()).toBe(
+      '<div>\n' +
+        '  <div>real child 1</div>\n' +
+        '  <div>real child 1</div>\n' +
+        '  <child2-custom-stub></child2-custom-stub>\n' +
+        '</div>'
+    )
 
     expect(customCreateStub).toHaveBeenCalledTimes(1)
-    expect(customCreateStub).toHaveBeenCalledWith({ name: 'child2', component: Child2 })
+    expect(customCreateStub).toHaveBeenCalledWith({
+      name: 'child2',
+      component: Child2
+    })
   })
 
   it('should not be called for no stubs', () => {
     const wrapper = mount(Parent)
 
-    expect(wrapper.html()).toBe('<div>\n' +
-      '  <div>real child 1</div>\n' +
-      '  <div>real child 1</div>\n' +
-      '  <div>real child 2</div>\n' +
-      '</div>')
+    expect(wrapper.html()).toBe(
+      '<div>\n' +
+        '  <div>real child 1</div>\n' +
+        '  <div>real child 1</div>\n' +
+        '  <div>real child 2</div>\n' +
+        '</div>'
+    )
 
     expect(customCreateStub).not.toHaveBeenCalled()
   })
@@ -181,13 +192,18 @@ describe('createStubs', () => {
       }
     })
 
-    expect(wrapper.html()).toBe('<div>\n' +
-      '  <child1-custom-stub></child1-custom-stub>\n' +
-      '  <child1-custom-stub></child1-custom-stub>\n' +
-      '  <div>Child 2 stub</div>\n' +
-      '</div>')
+    expect(wrapper.html()).toBe(
+      '<div>\n' +
+        '  <child1-custom-stub></child1-custom-stub>\n' +
+        '  <child1-custom-stub></child1-custom-stub>\n' +
+        '  <div>Child 2 stub</div>\n' +
+        '</div>'
+    )
 
     expect(customCreateStub).toHaveBeenCalledTimes(1)
-    expect(customCreateStub).toHaveBeenCalledWith({ name: 'child1', component: Child1 })
+    expect(customCreateStub).toHaveBeenCalledWith({
+      name: 'child1',
+      component: Child1
+    })
   })
 })


### PR DESCRIPTION
Adds a new plugin API to `config.plugins` called `createStubs` which will override the default stub creation provided by VTU.

Usage:
```ts
config.plugins.createStubs = ({ name, component }) => {
  return defineComponent({
    render: () => h(`custom-${name}-stub`)
  })
}
```
When VTU creates a stub either from `shallow: true` or `stubs: { ChildComponent: true }`, then the provided function will be called.

This will allow to implement different custom logics which are mentioned here:
* https://github.com/vuejs/vue-test-utils-next/issues/773#issuecomment-885182483
* https://github.com/vuejs/vue-test-utils-next/issues/945
* https://github.com/vuejs/vue-test-utils-next/pull/1174
* https://github.com/vuejs/vue-test-utils-next/issues/1179
* https://github.com/vuejs/vue-test-utils-next/issues/69

I have not updated the docs yet, but I will if it is good.

Closes #1216 