### PR TITLE
fix: static imports

### DIFF
--- a/tests/components/ScriptSetupWithChildren.vue
+++ b/tests/components/ScriptSetupWithChildren.vue
@@ -4,11 +4,12 @@ import { defineAsyncComponent } from 'vue'
 import Hello from './Hello.vue'
 import ComponentWithInput from './ComponentWithInput.vue'
 import ComponentWithoutName from './ComponentWithoutName.vue'
+import ScriptSetup from './ScriptSetup.vue'
+import WithProps from './WithProps.vue'
+
 const ComponentAsync = defineAsyncComponent(
   () => import('./ComponentWithoutName.vue')
 )
-import ScriptSetup from './ScriptSetup.vue'
-import WithProps from './WithProps.vue'
 </script>
 
 <template>


### PR DESCRIPTION
This should fix the error blocking the upgrade to vue-tsc v0.31.1

```
tests/components/ScriptSetupWithChildren.vue:10:1 - error TS1232: An import declaration can only be used in a namespace or module.

10 import ScriptSetup from './ScriptSetup.vue'
   ~~~~~~

tests/components/ScriptSetupWithChildren.vue:11:1 - error TS1232: An import declaration can only be used in a namespace or module.

11 import WithProps from './WithProps.vue'
   ~~~~~~
```