### PR TITLE
chore: re-add @vue/compiler-dom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/pretty": "^2.0.1",
     "@vue/babel-plugin-jsx": "^1.1.1",
     "@vue/compat": "3.2.29",
+    "@vue/compiler-dom": "3.2.29",
     "@vue/compiler-sfc": "3.2.29",
     "babel-jest": "^26.6.3",
     "babel-preset-jest": "^27.5.1",


### PR DESCRIPTION
It turns out we are stilll using it, and that removing the explicit dependency bothers Yarn 2.

Hopefully fixes #1306

This reverts f61b8aeb84352b29e29666326939531cd81c3bd6