### PR TITLE
test: Add tests for shallowMount issue with dynamic components

### DIFF
--- a/src/utils/componentName.ts
+++ b/src/utils/componentName.ts
@@ -11,7 +11,8 @@ const getComponentNameInSetup = (
   type: VNodeTypes
 ): string | undefined =>
   Object.keys(instance?.setupState || {}).find(
-    (key) => instance.setupState[key] === type
+    (key) =>
+      Object.getOwnPropertyDescriptor(instance.setupState, key)?.value === type
   )
 
 export const getComponentRegisteredName = (

--- a/tests/components/DynamicComponentWithComputedProperty.vue
+++ b/tests/components/DynamicComponentWithComputedProperty.vue
@@ -1,0 +1,19 @@
+<template>
+  <component :is="Hello" />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import Hello from './Hello.vue'
+import ComponentWithChildren from './ComponentWithChildren.vue'
+
+interface Props {
+  isHello?: boolean
+}
+
+const props = defineProps<Props>()
+
+const computedProperty = computed(() => {
+  return props.isHello ? Hello : ComponentWithChildren
+})
+</script>

--- a/tests/components/DynamicComponentWithComputedProperty.vue
+++ b/tests/components/DynamicComponentWithComputedProperty.vue
@@ -1,19 +1,10 @@
 <template>
-  <component :is="Hello" />
+  <component :is="computedProperty" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import Hello from './Hello.vue'
-import ComponentWithChildren from './ComponentWithChildren.vue'
 
-interface Props {
-  isHello?: boolean
-}
-
-const props = defineProps<Props>()
-
-const computedProperty = computed(() => {
-  return props.isHello ? Hello : ComponentWithChildren
-})
+const computedProperty = computed(() => Hello)
 </script>

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -198,24 +198,14 @@ describe('shallowMount', () => {
     )
   })
 
-  it('stubs a given component that is not returned by a computed property', () => {
+  it('stubs a given component that is also returned by a computed property', () => {
     const wrapper = shallowMount(DynamicComponentWithComputedProperty)
 
     expect(wrapper.find('hello-stub').exists()).toBe(true)
   })
 
-  it('stubs a given component that is also returned by a computed property', () => {
-    const wrapper = shallowMount(DynamicComponentWithComputedProperty, {
-      props: { isHello: true }
-    })
-
-    expect(wrapper.find('hello-stub').exists()).toBe(true)
-  })
-
   it('does not attempt to stub a dynamic component based on the name of a computed property', () => {
-    const wrapper = shallowMount(DynamicComponentWithComputedProperty, {
-      props: { isHello: true }
-    })
+    const wrapper = shallowMount(DynamicComponentWithComputedProperty)
 
     expect(wrapper.find('computed-property-stub').exists()).toBe(false)
   })

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -2,6 +2,7 @@ import { defineAsyncComponent, defineComponent } from 'vue'
 import { mount, shallowMount, VueWrapper } from '../src'
 import ComponentWithChildren from './components/ComponentWithChildren.vue'
 import ScriptSetupWithChildren from './components/ScriptSetupWithChildren.vue'
+import DynamicComponentWithComputedProperty from './components/DynamicComponentWithComputedProperty.vue'
 
 describe('shallowMount', () => {
   it('renders props for stubbed component in a snapshot', () => {
@@ -195,5 +196,27 @@ describe('shallowMount', () => {
         '  <test-component-stub class="component 2"></test-component-stub>\n' +
         '</div>'
     )
+  })
+
+  it('stubs a given component that is not returned by a computed property', () => {
+    const wrapper = shallowMount(DynamicComponentWithComputedProperty)
+
+    expect(wrapper.find('hello-stub').exists()).toBe(true)
+  })
+
+  it('stubs a given component that is also returned by a computed property', () => {
+    const wrapper = shallowMount(DynamicComponentWithComputedProperty, {
+      props: { isHello: true }
+    })
+
+    expect(wrapper.find('hello-stub').exists()).toBe(true)
+  })
+
+  it('does not attempt to stub a dynamic component based on the name of a computed property', () => {
+    const wrapper = shallowMount(DynamicComponentWithComputedProperty, {
+      props: { isHello: true }
+    })
+
+    expect(wrapper.find('computed-property-stub').exists()).toBe(false)
   })
 })


### PR DESCRIPTION
This PR adds a minimal set of tests to describe issue #1277, which regards how dynamic components, when shallow mounted, are stubbed with the name of a computed property that returns a component's name instead of the component itself.

The test component outlines the most extreme error case: a computed property does not need to be referenced in order to trigger the issue, it merely needs to both exist and return the component that is directly referenced.

This PR now also implements a possible simple fix for the issue.

cc: @cexbrayat