### PR TITLE
fix: pass RouterLink slot props to RouterLinkStub slot

### DIFF
--- a/src/components/RouterLinkStub.ts
+++ b/src/components/RouterLinkStub.ts
@@ -1,4 +1,18 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, computed } from 'vue'
+
+// match return type of router.resolve: RouteLocation & { href: string }
+const defaultRoute = {
+  path: '/',
+  name: undefined as string | undefined,
+  redirectedFrom: undefined as object | undefined,
+  params: {},
+  query: {},
+  hash: '',
+  fullPath: '/',
+  matched: [] as object[],
+  meta: {},
+  href: '/'
+}
 
 // TODO: Borrow typings from vue-router-next
 export const RouterLinkStub = defineComponent({
@@ -8,10 +22,23 @@ export const RouterLinkStub = defineComponent({
     to: {
       type: [String, Object],
       required: true
+    },
+    custom: {
+      type: Boolean,
+      default: false
     }
   },
 
   render() {
-    return h('a', undefined, this.$slots?.default?.())
+    const route = computed(() => defaultRoute)
+    // mock reasonable return values to mimic vue-router's useLink
+    const children = this.$slots?.default?.({
+      route,
+      href: computed(() => route.value.href),
+      isActive: computed(() => false),
+      isExactActive: computed(() => false),
+      navigate: async () => {}
+    })
+    return this.custom ? children : h('a', undefined, children)
   }
 })

--- a/tests/RouterLinkStub.spec.ts
+++ b/tests/RouterLinkStub.spec.ts
@@ -1,0 +1,40 @@
+import { defineComponent, h } from 'vue'
+import { mount } from '../src'
+import { RouterLinkStub } from '../src/components/RouterLinkStub'
+
+describe('RouterLinkStub', () => {
+  it('renders an <a> element', () => {
+    const component = defineComponent({
+      template: '<RouterLink :to="{}">link text</RouterLink>'
+    })
+    const wrapper = mount(component, {
+      props: {},
+      global: { stubs: { RouterLink: RouterLinkStub } }
+    })
+
+    expect(wrapper.get('a').text()).toEqual('link text')
+  })
+
+  it('binds slot props', () => {
+    const SlotReceiver = defineComponent({
+      render: () => h('span'),
+      props: ['route', 'href', 'isActive', 'isExactActive', 'navigate']
+    })
+    const component = defineComponent({
+      components: { SlotReceiver },
+      template:
+        '<RouterLink :to="{}" v-slot="slotProps"><SlotReceiver v-bind="slotProps" /></RouterLink>'
+    })
+    const wrapper = mount(component, {
+      props: {},
+      global: { stubs: { RouterLink: RouterLinkStub } }
+    })
+    const slotVM = wrapper.findComponent(SlotReceiver).vm
+
+    expect(slotVM.route.value).toBeInstanceOf(Object)
+    expect(typeof slotVM.href.value).toBe('string')
+    expect(typeof slotVM.isActive.value).toBe('boolean')
+    expect(typeof slotVM.isExactActive.value).toBe('boolean')
+    expect(slotVM.navigate).toBeInstanceOf(Function)
+  })
+})


### PR DESCRIPTION
resolves #848 

Added a default "empty" route object based on what I've seen coming out of vue-router, and basic stupid values for the rest of the slot props. In my opinion, anyone who needs `RouterLink` to be a bit smarter can create their own stub or use the real thing.

I also added the `custom` prop behaviour since it was easy to lift from the real `RouterLink` but it's probably not necessary, I'd be happy to remove that.

I added some tests around `RouterLinkStub` just to verify my implementation, also happy to remove them if they add unnecessary weight to the test suite.