### PR TITLE
fix(find): find and findAll should not find itself on DOM wrappers

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -80,24 +80,22 @@ export default abstract class BaseWrapper<ElementType extends Node>
       }
     }
 
-    const elements = this.findAllDOMElements(selector)
+    const elements = this.findAll(selector)
     if (elements.length > 0) {
-      return createDOMWrapper(elements[0])
+      return elements[0]
     }
 
     return createWrapperError('DOMWrapper')
   }
 
-  findAll<K extends keyof HTMLElementTagNameMap>(
+  abstract findAll<K extends keyof HTMLElementTagNameMap>(
     selector: K
   ): DOMWrapper<HTMLElementTagNameMap[K]>[]
-  findAll<K extends keyof SVGElementTagNameMap>(
+  abstract findAll<K extends keyof SVGElementTagNameMap>(
     selector: K
   ): DOMWrapper<SVGElementTagNameMap[K]>[]
-  findAll<T extends Element>(selector: string): DOMWrapper<T>[]
-  findAll(selector: string): DOMWrapper<Element>[] {
-    return this.findAllDOMElements(selector).map(createDOMWrapper)
-  }
+  abstract findAll<T extends Element>(selector: string): DOMWrapper<T>[]
+  abstract findAll(selector: string): DOMWrapper<Element>[]
 
   // searching by string without specifying component results in WrapperLike object
   findComponent<T extends never>(selector: string): WrapperLike

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -1,7 +1,11 @@
 import { config } from './config'
 import BaseWrapper from './baseWrapper'
 import WrapperLike from './interfaces/wrapperLike'
-import { registerFactory, WrapperType } from './wrapperFactory'
+import {
+  createDOMWrapper,
+  registerFactory,
+  WrapperType
+} from './wrapperFactory'
 import { RefSelector } from './types'
 import { isRefSelector } from './utils'
 import { createWrapperError } from './errorWrapper'
@@ -38,6 +42,23 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
     }
 
     return result
+  }
+
+  findAll<K extends keyof HTMLElementTagNameMap>(
+    selector: K
+  ): DOMWrapper<HTMLElementTagNameMap[K]>[]
+  findAll<K extends keyof SVGElementTagNameMap>(
+    selector: K
+  ): DOMWrapper<SVGElementTagNameMap[K]>[]
+  findAll<T extends Element>(selector: string): DOMWrapper<T>[]
+  findAll(selector: string): DOMWrapper<Element>[] {
+    if (!(this.wrapperElement instanceof Element)) {
+      return []
+    }
+    return Array.from(
+      this.wrapperElement.querySelectorAll(selector),
+      createDOMWrapper
+    )
   }
 
   findAllComponents(selector: any): any {

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -15,6 +15,7 @@ import { mergeDeep } from './utils'
 import { getRootNodes } from './utils/getRootNodes'
 import { emitted, recordEvent } from './emit'
 import BaseWrapper from './baseWrapper'
+import type { DOMWrapper } from './domWrapper'
 import {
   createDOMWrapper,
   registerFactory,
@@ -79,6 +80,17 @@ export class VueWrapper<
 
   getCurrentComponent() {
     return this.vm.$
+  }
+
+  findAll<K extends keyof HTMLElementTagNameMap>(
+    selector: K
+  ): DOMWrapper<HTMLElementTagNameMap[K]>[]
+  findAll<K extends keyof SVGElementTagNameMap>(
+    selector: K
+  ): DOMWrapper<SVGElementTagNameMap[K]>[]
+  findAll<T extends Element>(selector: string): DOMWrapper<T>[]
+  findAll(selector: string): DOMWrapper<Element>[] {
+    return this.findAllDOMElements(selector).map(createDOMWrapper)
   }
 
   private attachNativeEventListener(): void {

--- a/tests/components/ParentComponent.vue
+++ b/tests/components/ParentComponent.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="parent">
+    <div class="first">child</div>
+    <div>child</div>
+    <div>child</div>
+  </div>
+</template>

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -1,7 +1,7 @@
 import { defineComponent, h, nextTick, Fragment } from 'vue'
-
 import { mount, VueWrapper } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
+import ParentComponent from './components/ParentComponent.vue'
 import MultipleRootRender from './components/MultipleRootRender.vue'
 
 describe('find', () => {
@@ -91,18 +91,6 @@ describe('find', () => {
 
     const wrapper = mount(Component)
     expect(wrapper.find('.foo').exists()).toBe(true)
-  })
-
-  it('returns the root element from dom wrapper if it matches', () => {
-    const Component = defineComponent({
-      render() {
-        return h('div', { class: 'foo' }, 'text')
-      }
-    })
-
-    const wrapper = mount(Component)
-    const domWrapper = wrapper.find('.foo')
-    expect(domWrapper.find('.foo').exists()).toBe(true)
   })
 
   it('can be chained', () => {
@@ -346,5 +334,37 @@ describe('findAll', () => {
       const wrapper = mount(MultipleRootRender)
       expect(wrapper.findAll('a')).toHaveLength(3)
     })
+  })
+
+  // https://github.com/vuejs/test-utils/issues/1233
+  it('finds 3 children', () => {
+    const wrapper = mount(ParentComponent)
+
+    const parent = wrapper.get('.parent')
+
+    expect(parent.findAll('div').length).toBe(3)
+  })
+
+  it('finds itself on Vue wrapper', () => {
+    const wrapper = mount(ParentComponent)
+
+    const parent = wrapper.get('div')
+
+    expect(parent.classes()).toContain('parent')
+  })
+
+  it('does not find itself on DOM node', () => {
+    const wrapper = mount(ParentComponent)
+
+    const parent = wrapper.get('.parent')
+
+    expect(parent.find('div').classes()).toContain('first')
+  })
+
+  // https://github.com/vuejs/test-utils/issues/1233
+  it('finds all divs with findAll', () => {
+    const wrapper = mount(ParentComponent)
+
+    expect(wrapper.findAll('div').length).toBe(4)
   })
 })


### PR DESCRIPTION
This is alternate approach to fix #1233 
Other approach: #1377

What I'm liking about this approach:

* we're not introducing any flags 
* we're just moving `findAll` implementation to `DOMWrapper`/`VueWrapper` to distinguish behavior on Vue wrapper / DOM (semantics :1st_place_medal: )

