### PR TITLE
test: add test for modifying plugins globally via test runner hook

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -1,3 +1,6 @@
+import { defineComponent, h } from 'vue'
+import { config } from './src'
+
 const originalConsole = console.info
 
 console.info = (...args) => {
@@ -15,3 +18,15 @@ console.info = (...args) => {
 if (__USE_BUILD__) {
   jest.mock('./src', () => jest.requireActual('./dist/vue-test-utils.cjs'))
 }
+
+class TestPlugin {
+  static install (app) {
+    app.component('foo-bar', defineComponent({
+      render() {
+        return h('div', 'Foo Bar')
+      }
+    }))
+  }
+}
+
+config.global.plugins.push(TestPlugin)

--- a/setup.js
+++ b/setup.js
@@ -21,7 +21,7 @@ if (__USE_BUILD__) {
 
 class TestPlugin {
   static install (app) {
-    app.component('foo-bar', defineComponent({
+    app.component('foo-bar-plugin-component', defineComponent({
       render() {
         return h('div', 'Foo Bar')
       }

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -345,4 +345,16 @@ describe('config', () => {
       expect(wrapper.html()).toContain('local foo stub')
     })
   })
+
+  describe('global plugin via test runner setup script', () => {
+    it('uses a component defined globally by a test runner setup script', () => {
+      const Comp = defineComponent({
+        template: `<foo-bar />`
+      })
+
+      const wrapper = mount(Comp)
+
+      expect(wrapper.html()).toContain('Foo Bar')
+    })
+  })
 })

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -345,16 +345,4 @@ describe('config', () => {
       expect(wrapper.html()).toContain('local foo stub')
     })
   })
-
-  describe('global plugin via test runner setup script', () => {
-    it('uses a component defined globally by a test runner setup script', () => {
-      const Comp = defineComponent({
-        template: `<foo-bar />`
-      })
-
-      const wrapper = mount(Comp)
-
-      expect(wrapper.html()).toContain('Foo Bar')
-    })
-  })
 })

--- a/tests/configGlobal.spec.ts
+++ b/tests/configGlobal.spec.ts
@@ -1,0 +1,14 @@
+import { defineComponent } from 'vue'
+import { mount } from '../src'
+
+describe('global plugin via test runner setup script', () => {
+  it('uses a component defined globally by a test runner setup script', () => {
+    const Comp = defineComponent({
+      template: `<foo-bar />`
+    })
+
+    const wrapper = mount(Comp)
+
+    expect(wrapper.html()).toContain('Foo Bar')
+  })
+})

--- a/tests/configGlobal.spec.ts
+++ b/tests/configGlobal.spec.ts
@@ -4,7 +4,7 @@ import { mount } from '../src'
 describe('global plugin via test runner setup script', () => {
   it('uses a component defined globally by a test runner setup script', () => {
     const Comp = defineComponent({
-      template: `<foo-bar />`
+      template: `<foo-bar-plugin-component />`
     })
 
     const wrapper = mount(Comp)


### PR DESCRIPTION
Try to reproduce bug described here: https://github.com/jdfwarrior/vtu-plugin-issue

I think it may be Vitest specific; but we should still have a test for it here.