### PR TITLE
Fix typo in vue-router.md

### DIFF
--- a/docs/guide/advanced/vue-router.md
+++ b/docs/guide/advanced/vue-router.md
@@ -33,7 +33,7 @@ const Component = {
 }
 ```
 
-We could use a real router, then navigate to the correct route for this component, then after clicking the button assert that the correct page is rendered... however, this is a lot of setup for a relatively simple test. At it's core, the test we want to write is "if authenticated, redirect to X, otherwise redirect to Y". Let's see how we might accomplish this by mocking the routing using the `global.mocks` property:
+We could use a real router, then navigate to the correct route for this component, then after clicking the button assert that the correct page is rendered... however, this is a lot of setup for a relatively simple test. At its core, the test we want to write is "if authenticated, redirect to X, otherwise redirect to Y". Let's see how we might accomplish this by mocking the routing using the `global.mocks` property:
 
 ```js
 import { mount } from '@vue/test-utils';


### PR DESCRIPTION
This PR fixes a typo in `vue-router.md`: "at it's core" 👉  "at its core".