### PR TITLE
fix: remove compilerOptions from config

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,10 +26,6 @@ function mergeAppConfig(
     globalProperties: {
       ...configGlobalConfig?.globalProperties,
       ...mountGlobalConfig?.globalProperties
-    },
-    compilerOptions: {
-      ...configGlobalConfig?.compilerOptions,
-      ...mountGlobalConfig?.compilerOptions
     }
   }
 }

--- a/tests/features/compat.spec.ts
+++ b/tests/features/compat.spec.ts
@@ -3,13 +3,9 @@ import { mount } from '../../src'
 
 jest.mock('vue', () => mockVue)
 
-const { configureCompat, extend, defineComponent, h, config } = mockVue as any
+const { configureCompat, extend, defineComponent, h } = mockVue as any
 
 describe('@vue/compat build', () => {
-  beforeAll(() => {
-    config.compilerOptions.whitespace = 'condense'
-  })
-
   describe.each(['suppress-warning', false])(
     'when RENDER_FUNCTION compat is %p',
     (RENDER_FUNCTION) => {


### PR DESCRIPTION
This option was not used, and not exposed in the typings.
This was misleading as developers can imagine that setting `compilerOptions` in the config is the proper way to configure Vue.
This should be done either by:
- setting the options via https://github.com/vuejs/vue-jest#global-jest-options for Jest and vue-jest
- setting the options in Vite directly for vitest