### PR TITLE
fix: string slot null ctx in renderFn

### DIFF
--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -28,7 +28,7 @@ export function processSlot(source = '', Vue = vue) {
   )
   const renderFn = createRenderFunction(Vue)
   return (ctx = {}) => {
-    const result = renderFn()
+    const result = renderFn(ctx)
     const slotName = Object.keys(result.children)[0]
     return result.children[slotName](ctx)
   }


### PR DESCRIPTION
Fix for #1166. Render function requires ctx as the first param. This was not being passed in so was always null and erroring out. Bit confused why this only seems to be happening for Mocha users. Seems like it would be null for everyone.