### PR TITLE
fix(findComponent): allow finding top-level component

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -22,7 +22,11 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
   }
 
   getCurrentComponent() {
-    return this.element.__vueParentComponent
+    let component = this.element.__vueParentComponent
+    while (component?.parent?.vnode.el === this.element) {
+      component = component.parent
+    }
+    return component
   }
 
   find<K extends keyof HTMLElementTagNameMap>(

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -510,5 +510,34 @@ describe('findComponent', () => {
           .classes('inside')
       ).toBe(true)
     })
+
+    it('finds top component when searching from nested node', () => {
+      const DeepNestedComponent = defineComponent({
+        template: '<div class="deep-nested"></div>'
+      })
+
+      const NestedComponent = defineComponent({
+        components: { DeepNestedComponent },
+        template: '<deep-nested-component />'
+      })
+
+      const RootComponent = defineComponent({
+        components: { NestedComponent },
+        template: '<nested-component />'
+      })
+
+      const wrapper = mount(RootComponent)
+      expect(
+        wrapper.find('.deep-nested').findComponent(DeepNestedComponent).exists()
+      ).toBe(true)
+
+      expect(
+        wrapper.find('.deep-nested').findComponent(NestedComponent).exists()
+      ).toBe(true)
+
+      expect(
+        wrapper.find('.deep-nested').findComponent(RootComponent).exists()
+      ).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
Let's assume following rendering structure: 
```mermaid
flowchart LR
    RootComponent:::cmp --> NestedComponent:::cmp --> d(div.someclass):::dom
    classDef cmp fill:blue,color:white;
    classDef dom fill:darkgreen,color:white;
```

In this case
```js
mount(RootComponent).find('.some-class').find(NestedComponent).exists() // true
mount(RootComponent).find('.some-class').find(RootComponent).exists() // false
```

This is because `__vueParentComponent` will point to component who **actually** rendered dom node
To fix this we traverse ancestors of `__vueParentComponent` while their `vnode.element` is equal to current dom node and use resulted vue component as base for our search

