### PR TITLE
export package.json from module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "browser": "./dist/vue-test-utils.browser.js",
       "require": "./dist/vue-test-utils.cjs.js",
       "default": "./dist/vue-test-utils.cjs.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
See https://github.com/nodejs/modules/issues/445 for context. This package doesn't export its own package.json ever since the exports were added, which breaks some tooling I've written to help me with upgrading from VTU 1 to VTU 2 that tries to read the package.json to get the installed version.