### PR TITLE
chore: add return type to createStub

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -9,7 +9,8 @@ import {
   VNodeTypes,
   ConcreteComponent,
   ComponentPropsOptions,
-  ComponentObjectPropsOptions
+  ComponentObjectPropsOptions,
+  DefineComponent
 } from 'vue'
 import { hyphenate } from './utils/vueShared'
 import { matchName } from './utils/matchName'
@@ -78,7 +79,7 @@ export const createStub = ({
   name,
   type,
   renderStubDefaultSlot
-}: StubOptions) => {
+}: StubOptions): DefineComponent => {
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 


### PR DESCRIPTION
Fixes the error:

```
src/index.ts → dist/vue-test-utils.esm-bundler.mjs...
[!] (plugin commonjs--resolver) Error: /home/runner/work/test-utils/test-utils/src/stubs.ts(77,14): semantic error TS2742: The inferred type of 'createStub' cannot be named without a reference to '@vue/compiler-dom/node_modules/@vue/shared'. This is likely not portable. A type annotation is necessary.
```

that we see when upgrading the lockfile in #1543