### PR TITLE
fix(utils): getRootNodes flattens only one depth of children

### DIFF
--- a/src/utils/getRootNodes.ts
+++ b/src/utils/getRootNodes.ts
@@ -25,9 +25,9 @@ export function getRootNodes(vnode: VNode): Node[] {
     }
     return result
   } else if (vnode.shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
-    const children = (vnode.children as unknown as VNodeArrayChildren).flat(
-      Infinity
-    ) as VNode[]
+    const children = (
+      vnode.children as unknown as VNodeArrayChildren
+    ).flat() as VNode[]
 
     return children
       .flatMap((vnode) => getRootNodes(vnode))


### PR DESCRIPTION
TS v4.7 is now trying to compute the type more accurately in `flat()` and `Infinity` is not playing very well: it throws
```
src/utils/getRootNodes.ts:28:22 - error TS2589: Type instantiation is excessively deep and possibly infinite
```

I'm wondering if we really need to flatten infinitely, as the following lines call `getRootNodes` recursively on each element. But as I'm a bit fuzzy on how this part of the code works, I'd like more informed opinions 😉