### PR TITLE
fix(types): Export BaseWrapper from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { DOMWrapper } from './domWrapper'
 import { VueWrapper } from './vueWrapper'
-import { BaseWrapper } from './baseWrapper'
+import BaseWrapper from './baseWrapper'
 import { mount, shallowMount } from './mount'
 import { MountingOptions } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { DOMWrapper } from './domWrapper'
 import { VueWrapper } from './vueWrapper'
+import { BaseWrapper } from './baseWrapper'
 import { mount, shallowMount } from './mount'
 import { MountingOptions } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
@@ -16,6 +17,7 @@ export {
   RouterLinkStub,
   VueWrapper,
   DOMWrapper,
+  BaseWrapper,
   config,
   flushPromises,
   MountingOptions,


### PR DESCRIPTION
BaseWrapper isn't exported like VueWrapper and DOMWrapper, even though it is exported from baseWrapper.ts. This means that any consumers who want to use the type have to import it from `@vue/test-utils/dist/baseWrapper` instead of `@vue/test-utils` like the others.