### PR TITLE
fix(compat): declare RouterLinkStub as compatibility mode 3

### DIFF
--- a/src/components/RouterLinkStub.ts
+++ b/src/components/RouterLinkStub.ts
@@ -18,6 +18,8 @@ const defaultRoute = {
 export const RouterLinkStub = defineComponent({
   name: 'RouterLinkStub',
 
+  compatConfig: { MODE: 3 },
+  
   props: {
     to: {
       type: [String, Object],

--- a/src/components/RouterLinkStub.ts
+++ b/src/components/RouterLinkStub.ts
@@ -19,7 +19,7 @@ export const RouterLinkStub = defineComponent({
   name: 'RouterLinkStub',
 
   compatConfig: { MODE: 3 },
-  
+
   props: {
     to: {
       type: [String, Object],


### PR DESCRIPTION
When running tests in Vue 2 mode under `@vue/compat`, RouterLinkStub's render function dies because of the change to the `$slots` API. Declaring it as mode 3 helps it "just work" for users regardless of Vue compatibility mode.