### PR TITLE
fix(compat): respect v-model in vue 2 with compat build

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -91,7 +91,7 @@ export const createStub = ({
     name: name || anonName,
     props: componentOptions.props || {},
     // fix #1550 - respect old-style v-model for shallow mounted components with @vue/compat
-    // @ts-ignore
+    // @ts-expect-error
     model: componentOptions.model,
     setup(props, { slots }) {
       return () => {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -83,13 +83,16 @@ export const createStub = ({
   const anonName = 'anonymous-stub'
   const tag = name ? `${hyphenate(name)}-stub` : anonName
 
-  const propsDeclaration = type
-    ? unwrapLegacyVueExtendComponent(type).props || {}
+  const componentOptions = type
+    ? unwrapLegacyVueExtendComponent(type) || {}
     : {}
 
   return defineComponent({
     name: name || anonName,
-    props: propsDeclaration,
+    props: componentOptions.props || {},
+    // fix #1550 - respect old-style v-model for shallow mounted components with @vue/compat
+    // @ts-ignore
+    model: componentOptions.model,
     setup(props, { slots }) {
       return () => {
         // https://github.com/vuejs/test-utils/issues/1076


### PR DESCRIPTION
Fixes #1550. 

I tried to write a test for this but it didn't pass. I think it's either because [vue-test-utils-compat](https://github.com/xanf/vue-test-utils-compat) is an additional step to make this work, or vue needs to be aliased to @vue/compat in the entire test suite, which I was a little hesitant to do. I saw that @vue/compat was already a dev dependency - not sure if we've tried to write tests like this in the past.