### PR TITLE
chore(emitted): Add test case for emitted pass-through events

### DIFF
--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -365,6 +365,35 @@ describe('emitted', () => {
     expect(wrapper.emitted().bar[1]).toEqual(['click'])
   })
 
+  it('captures pass through events', async () => {
+    const BaseInput = defineComponent({
+      props: {
+        modelValue: String
+      },
+      emits: ['update:modelValue'],
+      template: `<input :value="modelValue" @input="$emit('update:modelValue', $event.target.value)" />`
+    })
+
+    const CustomInput = defineComponent({
+      components: { BaseInput },
+      template: `<BaseInput v-bind="{ ...$attrs }"/>`
+    })
+
+    const wrapper = mount(CustomInput, {
+      props: {
+        modelValue: 'Text'
+      }
+    })
+
+    const input = wrapper.get('input')
+    await input.setValue('New Text')
+
+    const baseInput = wrapper.findComponent(BaseInput)
+    expect(baseInput.emitted('update:modelValue')).toEqual([['New Text']])
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['New Text']])
+  })
+
   it('does not clear all emitted event history on mount/unmount', async () => {
     const Foo = defineComponent({
       name: 'Foo',


### PR DESCRIPTION
Test for #1509

This is only an issue, when the root component uses the pass-through (`v-bind="$attrs"`). Passing a function as prop `onUpdate:modelValue` does call the function but not record the emitted event. It seems that the event is not catched by  devtools here: https://github.com/vuejs/test-utils/blob/3cc95f9a34656522806ee8431ccde80b2d626676/src/emit.ts#L35-L45