### PR TITLE
chore(types): improve typing of emitted

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -168,7 +168,7 @@ export class VueWrapper<
   }
 
   emitted<T = unknown>(): Record<string, T[]>
-  emitted<T = unknown>(eventName: string): undefined | T[]
+  emitted<T = unknown[]>(eventName: string): undefined | T[]
   emitted<T = unknown>(
     eventName?: string
   ): undefined | T[] | Record<string, T[]> {

--- a/test-dts/wrapper.d-test.ts
+++ b/test-dts/wrapper.d-test.ts
@@ -62,6 +62,11 @@ byClassArray = domWrapper.findAll('.todo')
 expectType<Element | undefined>(byClassArray[0].element)
 
 // emitted
+
+// event name without specific type
+let incrementEventWithoutType = wrapper.emitted('increment')
+expectType<unknown[][] | undefined>(incrementEventWithoutType)
+
 // event name
 let incrementEvent = wrapper.emitted<{ count: number }>('increment')
 expectType<{ count: number }[] | undefined>(incrementEvent)


### PR DESCRIPTION
I find pretty annoying usage of emitted with typescript:

```ts
    expect(wrapper.emitted<unknown[]>('input')[0][0]).toEqual(testItems)
```

Requirement to specify `<unknown[]>` is pretty sad - since emitted events is always an array of arrays

This PR updates typings to simplify such use case