### PR TITLE
bugfix: updated `mocks` params level

### DIFF
--- a/docs/guide/advanced/vue-router.md
+++ b/docs/guide/advanced/vue-router.md
@@ -52,11 +52,9 @@ test('allows authenticated user to edit a post', async () => {
     props: {
       isAuthenticated: true
     },
-    global: {
-      mocks: {
-        $route: mockRoute,
-        $router: mockRouter
-      }
+    mocks: {
+      $route: mockRoute,
+      $router: mockRouter
     }
   })
 


### PR DESCRIPTION
---
name: Feature request
about: Update the router mock testing documentation
title: 'Unnested mock param:'
labels: ''
assignees: ''

---

**Is your feature request related to a problem? Please describe.**
When testing a mounted component, the `global` prop does not exist anymore, `mocks` can be at the same level than `props`.

**Describe the solution you'd like**
To remove the global key so that `mocks` is at the same level than `props`

**Describe alternatives you've considered**
Specifying a change in versions with some sort of disclaimer so that newer users know where to put the key.

**Additional context**
I was trying to mock a router param and when refering to the documentation typescript suggested that global does not exist but `mocks` does, without it being nested inside `global`.