### PR TITLE
docs: update installation docs

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,10 +1,10 @@
 # Installation
 
 ```bash
-npm install --save-dev @vue/test-utils@next
+npm install --save-dev @vue/test-utils
 
 # or
-yarn add --dev @vue/test-utils@next
+yarn add --dev @vue/test-utils
 ```
 
 ## Usage


### PR DESCRIPTION
# docs: update installation docs

## :book: Description

Update installation docs to suggest the installation of the `latest` tag instead of the `next` tag.

## :bulb: Context

The latest tag currently points to `2.0.2` released 23 days ago while the `next` tag points to a fairly outdated version of `2.0.0-rc.18` released 7 months ago. It is probably a good idea to suggest latest stable version as the default version to be installed.


