### PR TITLE
chore: use es2016 as a TS target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2016",
     "outDir": "dist",
     "module": "esnext",
-    "lib": ["DOM", "ES2015", "ES2017"],
+    "lib": [
+      "DOM",
+      "ES2015",
+      "ES2017"
+    ],
     "strict": true,
     "jsx": "preserve",
     "moduleResolution": "node",


### PR DESCRIPTION
This should unblock the bump to Vite 3.
I used es2016 as it is the [same target used by vuejs/core](https://github.com/vuejs/core/blob/main/tsconfig.json)