### PR TITLE
chore: run tests in random order

### DIFF
--- a/tests/features/compat.spec.ts
+++ b/tests/features/compat.spec.ts
@@ -165,6 +165,12 @@ describe('@vue/compat build', () => {
   })
 
   it('wrapper.vm points to correct instance when component is wrapped with Vue.extend', () => {
+    configureCompat({
+      MODE: 3,
+      GLOBAL_EXTEND: 'suppress-warning',
+      GLOBAL_MOUNT: 'suppress-warning'
+    })
+
     const Component = extend({
       data() {
         return { foo: 'bar' }

--- a/tests/features/suspense.spec.ts
+++ b/tests/features/suspense.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import SuspenseComponent from '../components/Suspense.vue'
 import { mount, flushPromises } from '../../src'
 import { defineComponent } from 'vue'
@@ -11,6 +11,10 @@ vi.mock('../utils', () => ({
     }
   }
 }))
+
+beforeEach(() => {
+  mockShouldError = false
+})
 
 describe('suspense', () => {
   test('fallback state', () => {

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -395,19 +395,19 @@ describe('mounting options: stubs', () => {
 
   describe('transition', () => {
     it('stubs transition by default', () => {
-      const Comp = {
-        template: `<transition><div id="content" /></transition>`
+      const CompStubbedByDefault = {
+        template: `<transition><div id="content-stubbed-by-default" /></transition>`
       }
-      const wrapper = mount(Comp)
+      const wrapper = mount(CompStubbedByDefault)
 
       expect(wrapper.html()).toBe(
         '<transition-stub>\n' +
-          '  <div id="content"></div>\n' +
+          '  <div id="content-stubbed-by-default"></div>\n' +
           '</transition-stub>'
       )
     })
 
-    it('opts out of stubbing transition by default', () => {
+    it('opts out of stubbing transition', () => {
       const Comp = {
         template: `<transition><div id="content" /></transition>`
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
     include: ['tests/**/*.spec.ts'],
     deps: {
       inline: ['vue', '@vue/compat']
+    },
+    sequence: {
+      shuffle: true
     }
   },
   resolve: {


### PR DESCRIPTION
This fixes issues of some tests relying on others to run first.