### PR TITLE
chore: group vitest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,11 @@
   // auto-merge if build is OK
   "automerge": true,
   "packageRules": [
+    // group vitest packages update
+    {
+      groupName: 'vite',
+      matchPackagePrefixes: ['@vitest/', 'vitest'],
+    },
     // group vite packages update
     {
       groupName: 'vite',


### PR DESCRIPTION
It'll avoid two separate PRs for `vitest` and `@vitest/coverage-c8`