### PR TITLE
Update baseWrapper.ts

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -329,12 +329,9 @@ export default abstract class BaseWrapper<ElementType extends Node>
       'TEXTAREA',
       'INPUT'
     ]
-    const hasDisabledAttribute = this.attributes().disabled !== undefined
-    const elementCanBeDisabled =
-      isElement(this.element) &&
-      validTagsToBeDisabled.includes(this.element.tagName)
-
-    return hasDisabledAttribute && elementCanBeDisabled
+    const elementIsDisabled = this.attributes().disabled !== undefined && this.attributes().disabled !== 'false'
+    const elementCanBeDisabled = isElement(this.element) && validTagsToBeDisabled.includes(this.element.tagName)
+    return elementIsDisabled && elementCanBeDisabled
   }
 
   isVisible() {


### PR DESCRIPTION
The disabled attribute can be set to 'false', which means it is not disabled. 
The current isDisabled function does not check for that.

I'm aware the spec does not allow for false values (as per https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes), 
however when used in this situation e.g. 
 ```vue
<template>
    <component :is="type" :disabled="index > 1" @click="$emit('something')" data-testid="button"/>
</template>
```

And running a test like this:
```javascript
const wrapper = mount(Component, { props: { type: 'button' } })
const button = wrapper.find('[data-testid="button"]')
await button.trigger('click');
expect(wrapper.emitted()).toHaveProperty('something')
```
Does not work because the `this.attributes().disabled` returns `'false'` instead of `undefined`...