### PR TITLE
fix: Add props to stubs for built-in components

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -171,9 +171,10 @@ export function stubComponents(
       return [
         createStub({
           name: 'transition',
+          type: type as any,
           renderStubDefaultSlot: true
         }),
-        undefined,
+        props,
         children
       ]
     }
@@ -185,9 +186,10 @@ export function stubComponents(
       return [
         createStub({
           name: 'transition-group',
+          type: type as any,
           renderStubDefaultSlot: true
         }),
-        undefined,
+        props,
         children
       ]
     }
@@ -199,9 +201,10 @@ export function stubComponents(
       return [
         createStub({
           name: 'teleport',
+          type: type as any,
           renderStubDefaultSlot: true
         }),
-        undefined,
+        props,
         () => children
       ]
     }

--- a/tests/features/transition.spec.ts
+++ b/tests/features/transition.spec.ts
@@ -1,11 +1,20 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { WithTransition } from '../components/WithTransition'
 import { mount } from '../../src'
 
-test('works with transitions', async () => {
-  const wrapper = mount(WithTransition)
-  expect(wrapper.find('#message').exists()).toBe(false)
+describe('transitions', () => {
+  test('work', async () => {
+    const wrapper = mount(WithTransition)
+    expect(wrapper.find('#message').exists()).toBe(false)
 
-  await wrapper.find('button').trigger('click')
-  expect(wrapper.find('#message').exists()).toBe(true)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.find('#message').exists()).toBe(true)
+  })
+
+  test('have props', () => {
+    const wrapper = mount(WithTransition)
+    expect(wrapper.getComponent({ name: 'transition' }).props('name')).toBe(
+      'fade'
+    )
+  })
 })

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -401,7 +401,7 @@ describe('mounting options: stubs', () => {
       const wrapper = mount(CompStubbedByDefault)
 
       expect(wrapper.html()).toBe(
-        '<transition-stub>\n' +
+        '<transition-stub appear="false" persisted="false" css="true">\n' +
           '  <div id="content-stubbed-by-default"></div>\n' +
           '</transition-stub>'
       )
@@ -513,7 +513,7 @@ describe('mounting options: stubs', () => {
       })
 
       expect(wrapper.html()).toBe(
-        '<teleport-stub>\n' +
+        '<teleport-stub to="body">\n' +
           '  <div id="content"></div>\n' +
           '</teleport-stub>'
       )


### PR DESCRIPTION
The stubs for `<transition>`, `<transition-group>` and `<teleport>` don't have any props defined, which currently makes it impossible to test for those to be set correctly.

Took the props to add from https://vuejs.org/api/built-in-components.html.