### PR TITLE
wip: support extending mounting options

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -294,9 +294,9 @@ export function mount<
 >
 
 // implementation
-export function mount(
+export function mount<Ext = {}>(
   inputComponent: any,
-  options?: MountingOptions<any> & Record<string, any>
+  options?: MountingOptions<any> & Ext
 ): VueWrapper<any> {
   // normalize the incoming component
   const originalComponent = unwrapLegacyVueExtendComponent(inputComponent)
@@ -561,3 +561,24 @@ export function mount(
 export const shallowMount: typeof mount = (component: any, options?: any) => {
   return mount(component, { ...options, shallow: true })
 }
+
+const C = defineComponent({
+  render () {
+    return h('div')
+  } 
+})
+
+interface Foo {
+  /**
+   * it's foo
+   */
+  foo: string
+}
+
+const myMount: typeof mount<Foo> = (c: any, o?: any) => {
+  return mount(c, o)
+}
+
+myMount(C, {
+  foo: 'string'
+})


### PR DESCRIPTION
Some libraries like Cypress and Playwright and Testing Library would like to extend Test Utils by adding some new mounting options, whilst maintaining the type safety.

Testing Library example: we need to use `any`: https://github.com/testing-library/vue-testing-library/blob/6dd48477002760262652dd047de0897762bd60c4/types/index.d.ts#L51

Eg: maybe you want to add a special `foo` mounting option.

```ts
mount(Comp, {
  foo: 'bar'
})
```

I'm not sure how to extend our types to do this. I took a stab but it's not really working.

I think the ideal API might be:

```ts
export const myMount: typeof mount<{ foo: string }> = (comp, opts) => {
  // do something with foo
  console.log('You passed foo!', opts.foo)
  return mount(comp, opts)
}
```

Basically I'd like support "wrapping" mount and extending it. Is this something we can do?

Edit: I tried something a little different but more simple, still no luck: https://github.com/vuejs/test-utils/pull/1780

Edit edit: got some tips, see this comment: https://github.com/cypress-io/cypress/issues/23653#issuecomment-1251792959