### PR TITLE
fix(compat): do not overwrite globalProperties merge them instead

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -30,6 +30,7 @@ import {
 import { MountingOptions, Slot } from './types'
 import {
   isFunctionalComponent,
+  isObject,
   isObjectComponent,
   mergeGlobalProperties
 } from './utils'
@@ -474,7 +475,9 @@ export function mount(
       keyof Omit<AppConfig, 'isNativeTag'>,
       any
     ][]) {
-      app.config[k] = v
+      app.config[k] = isObject(app.config[k])
+        ? Object.assign(app.config[k]!, v)
+        : v
     }
   }
 

--- a/tests/features/compat.spec.ts
+++ b/tests/features/compat.spec.ts
@@ -3,8 +3,9 @@ import * as mockVue from '@vue/compat'
 import { mount } from '../../src'
 
 vi.mock('vue', () => mockVue)
-
 const { configureCompat, extend, defineComponent, h } = mockVue
+// @ts-expect-error @vue/compat does not expose default export in types
+const Vue = mockVue.default
 
 describe('@vue/compat build', () => {
   describe.each(['suppress-warning', false])(
@@ -212,5 +213,20 @@ describe('@vue/compat build', () => {
     expect(wrapper.html()).toBe(
       '<div class="foo" text="message" style="color: red;">message</div>'
     )
+  })
+
+  it('does not erase globalProperties added by messing with Vue.prototype', () => {
+    configureCompat({
+      MODE: 3,
+      GLOBAL_PROTOTYPE: 'suppress-warning'
+    })
+
+    Vue.prototype.$test = 1
+
+    const Component = { template: 'hello ' }
+    const wrapper = mount(Component)
+
+    // @ts-expect-error $test "magically" appears from "Vue.prototype" in compat build
+    expect(wrapper.vm.$test).toBe(1)
   })
 })


### PR DESCRIPTION
* globalProperties might not be empty due to them being gathered from `Vue.prototype` when using compat build

By overwriting this properties any "legacy" plugin configuration, which adds properties via `Vue.prototype` will loose them, cause we will overwrite `globalProperties` with default empty object