### PR TITLE
fix(element): return correct element for component which renders other component while passing array of vnodes in default slot

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -74,18 +74,18 @@ export class VueWrapper<
     const checkTree = (subTree: VNode): boolean => {
       // if the subtree is an array of children, we have multiple root nodes
       if (subTree.shapeFlag === ShapeFlags.ARRAY_CHILDREN) return true
-
       if (
         subTree.shapeFlag & ShapeFlags.STATEFUL_COMPONENT ||
         subTree.shapeFlag & ShapeFlags.FUNCTIONAL_COMPONENT
       ) {
-        // Component has multiple children or slot with multiple children
-        if (subTree.shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
-          return true
-        }
-
+        // We are rendering other component, check it's tree instead
         if (subTree.component?.subTree) {
           return checkTree(subTree.component.subTree)
+        }
+
+        // Component has multiple children
+        if (subTree.shapeFlag & ShapeFlags.ARRAY_CHILDREN) {
+          return true
         }
       }
 

--- a/tests/element.spec.ts
+++ b/tests/element.spec.ts
@@ -105,4 +105,14 @@ describe('element', () => {
       '<div>foo</div><div>bar</div><div>baz</div>'
     )
   })
+
+  it('returns correct element for component which renders other component with array of vnodes in default slot', () => {
+    const Nested = {
+      template: '<div class="nested-root"><slot></slot></div>'
+    }
+    const Root = () => h(Nested, {}, [h('div', {}, 'foo'), h('div', {}, 'bar')])
+
+    const wrapper = mount(Root)
+    expect(wrapper.element.innerHTML).toBe('<div>foo</div><div>bar</div>')
+  })
 })


### PR DESCRIPTION
While rendering array of vnodes in slot is discouraged (Vue complains about it and suggest using function for default slot for performance) - it is still valid according to https://vuejs.org/guide/extras/render-function.html#creating-vnodes

```js
// children array can contain mixed vnodes and strings
h('div', ['hello', h('span', 'hello')])
```

This fixes for me multiple tests wheb using `@vue/compat` with legacy codebase, where rendering array of vnodes was considered more performant :(
