### PR TITLE
fix(config): Do not use config.renderStubDefaultSlot

### DIFF
--- a/docs/guide/advanced/stubs-shallow-mount.md
+++ b/docs/guide/advanced/stubs-shallow-mount.md
@@ -275,11 +275,11 @@ For this use case, you can use `config.renderStubDefaultSlot`, which will render
 import { config, mount } from '@vue/test-utils'
 
 beforeAll(() => {
-  config.renderStubDefaultSlot = true
+  config.global.renderStubDefaultSlot = true
 })
 
 afterAll(() => {
-  config.renderStubDefaultSlot = false
+  config.global.renderStubDefaultSlot = false
 })
 
 test('shallow with stubs', () => {
@@ -316,4 +316,4 @@ So regardless of which mounting method you choose, we suggest keeping these guid
 
 - use `global.stubs` to replace a component with a dummy one to simplify your tests
 - use `shallow: true` (or `shallowMount`) to stub out all child components
-- use `config.renderStubDefaultSlot` to render the default `<slot>` for a stubbed component
+- use `global.renderStubDefaultSlot` to render the default `<slot>` for a stubbed component

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -206,7 +206,7 @@ You can enable the old behavior like this:
 ```js
 import { config } from '@vue/test-utils'
 
-config.renderStubDefaultSlot = true
+config.global.renderStubDefaultSlot = true
 ```
 
 ### `destroy` is now `unmount` to match Vue 3

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,10 @@ export interface GlobalConfigOptions {
     DOMWrapper: Pluggable<DOMWrapper<Node>>
     createStubs?: CustomCreateStub
   }
-  renderStubDefaultSlot: boolean
+  /**
+   * @deprecated use global.
+   */
+  renderStubDefaultSlot?: boolean
 }
 
 interface Plugin<Instance, O> {
@@ -80,6 +83,5 @@ export const config: GlobalConfigOptions = {
   plugins: {
     VueWrapper: new Pluggable(),
     DOMWrapper: new Pluggable()
-  },
-  renderStubDefaultSlot: false
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,8 +40,14 @@ export function mergeGlobalProperties(
 
   const renderStubDefaultSlot =
     mountGlobal.renderStubDefaultSlot ??
-    config?.renderStubDefaultSlot ??
-    configGlobal?.renderStubDefaultSlot
+    (configGlobal.renderStubDefaultSlot || config?.renderStubDefaultSlot) ??
+    false
+
+  if (config.renderStubDefaultSlot === true) {
+    console.warn(
+      'config.renderStubDefaultSlot is deprecated, use config.global.renderStubDefaultSlot instead'
+    )
+  }
 
   return {
     mixins: [...(configGlobal.mixins || []), ...(mountGlobal.mixins || [])],

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -731,11 +731,11 @@ describe('mounting options: stubs', () => {
     }
 
     afterEach(() => {
-      config.renderStubDefaultSlot = false
+      config.global.renderStubDefaultSlot = false
     })
 
     it('renders only the default stub slot only behind flag', () => {
-      config.renderStubDefaultSlot = true
+      config.global.renderStubDefaultSlot = true
 
       const wrapper = mount(Component, {
         global: {
@@ -750,7 +750,7 @@ describe('mounting options: stubs', () => {
     })
 
     it('renders none of the slots on a stub', () => {
-      config.renderStubDefaultSlot = false
+      config.global.renderStubDefaultSlot = false
       const wrapper = mount(Component, {
         global: {
           stubs: ['ComponentWithSlots']
@@ -764,7 +764,7 @@ describe('mounting options: stubs', () => {
     })
 
     it('renders the default slot of deeply nested stubs when renderStubDefaultSlot=true', () => {
-      config.renderStubDefaultSlot = true
+      config.global.renderStubDefaultSlot = true
 
       const SimpleSlot = {
         name: 'SimpleSlot',


### PR DESCRIPTION
Right now I've spent 30 minutes figuring why my default slots in stubs were not rendered, just to figure out, that our docs mention `global.renderStubDefaultSlot` as the way to control stub behavior, however we have **both** `config.renderStubDefaultSlot` and `config.global.renderStubDefaultSlot` with first being a preference

While **technically** this is a breaking change, I find an ability to define same thing in two places extremely confusing and fix for affected codebases will be trivial (swap `config.renderStubDefaultSlot` with `config.global.renderStubDefaultSlot`)

Otherwise, if we decide that we do not want to have such breaking change, I suggest swapping priority, so `config.global.renderStubDefaultSlot` will be taken into account before `config.renderStubDefaultSlot` and mark `config.renderStubDefaultSlot` as deprecated