### PR TITLE
feat(stubs): Allow to stub directives (fixes #1800)

### DIFF
--- a/docs/guide/advanced/stubs-shallow-mount.md
+++ b/docs/guide/advanced/stubs-shallow-mount.md
@@ -304,10 +304,10 @@ test('stubs component with custom template', () => {
 })
 ```
 
-We've just swapped our directive implementation with own one!
+We've just swapped our directive implementation with our own one!
 
 ::: warning
-Stubbing directives won't work on functional components or `<script setup>` due to lack of directive name inside of [withDirectives](https://vuejs.org/api/render-function.html#withdirectives) function. Consider mocking directive module via your testing framework if you need to mock directive used in functional component
+Stubbing directives won't work on functional components or `<script setup>` due to lack of directive name inside of [withDirectives](https://vuejs.org/api/render-function.html#withdirectives) function. Consider mocking directive module via your testing framework if you need to mock directive used in functional component. See https://github.com/vuejs/core/issues/6887 for proposal to unlock such functionality
 :::
 
 ## Default Slots and `shallow`

--- a/docs/guide/advanced/stubs-shallow-mount.md
+++ b/docs/guide/advanced/stubs-shallow-mount.md
@@ -255,7 +255,7 @@ const App = {
 }
 ```
 
-We do not want `Tooltip` directive code to be executed in this test, we just want to assert the message is rendered. In this case, we could use the `stubs`, which appears in the `global` mounting option passing `vTooltip`.
+We do not want the `Tooltip` directive code to be executed in this test, we just want to assert the message is rendered. In this case, we could use the `stubs`, which appears in the `global` mounting option passing `vTooltip`.
 
 ```js
 test('stubs component with custom template', () => {
@@ -268,7 +268,7 @@ test('stubs component with custom template', () => {
   })
 
   console.log(wrapper.html())
-  // <h1>Welcome to Vue.js 3</h1><span></span>
+  // <h1>Welcome to Vue.js 3</h1>
 
   expect(wrapper.html()).toContain('Welcome to Vue.js 3')
 })
@@ -298,7 +298,7 @@ test('stubs component with custom template', () => {
   // 'directive called' logged to console
 
   console.log(wrapper.html())
-  // <h1>Welcome to Vue.js 3</h1><span></span>
+  // <h1 class="with-tooltip">Welcome to Vue.js 3</h1>
 
   expect(wrapper.classes('with-tooltip')).toBe(true)
 })
@@ -307,7 +307,7 @@ test('stubs component with custom template', () => {
 We've just swapped our directive implementation with own one!
 
 ::: warning
-Stubbing directives won't work on functional components due to lack of directive name inside of [withDirectives](https://vuejs.org/api/render-function.html#withdirectives) function. Consider mocking directive module via your testing framework if you need to mock directive used in functional component
+Stubbing directives won't work on functional components or `<script setup>` due to lack of directive name inside of [withDirectives](https://vuejs.org/api/render-function.html#withdirectives) function. Consider mocking directive module via your testing framework if you need to mock directive used in functional component
 :::
 
 ## Default Slots and `shallow`

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -341,7 +341,7 @@ export function mount(
   }
 
   addToDoNotStubComponents(component)
-  // We've just replaced our component with it's copy
+  // We've just replaced our component with its copy
   // Let's register it as a stub so user can find it
   registerStub({ source: originalComponent, stub: component })
 

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,0 +1,32 @@
+import { Component } from 'vue'
+
+// Stubbing occurs when in vnode transformer we're swapping
+// component vnode type due to stubbing either component
+// or directive on component
+
+// In order to be able to find components we need to track pairs
+// stub --> original component
+
+// Having this as global might feel unsafe at first point
+// One can assume that sharing stub map across mounts might
+// lead to false matches, however our vnode mappers always
+// produce new nodeTypes for each mount even if you're reusing
+// same stub, so we're safe and do not need to pass these stubs
+// for each mount operation
+const stubs: WeakMap<Component, Component> = new WeakMap()
+
+export function registerStub({
+  source,
+  stub
+}: {
+  source: Component
+  stub: Component
+}) {
+  stubs.set(stub, source)
+}
+
+export function getOriginalComponentFromStub(
+  stub: Component
+): Component | undefined {
+  return stubs.get(stub)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,7 +86,7 @@ export interface MountingOptions<Props, Data = {}> {
   shallow?: boolean
 }
 
-export type Stub = boolean | Component
+export type Stub = boolean | Component | Directive
 export type Stubs = Record<string, Stub> | Array<string>
 export type GlobalMountOptions = {
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
-import { GlobalMountOptions, RefSelector } from './types'
-import { ComponentOptions, ConcreteComponent, FunctionalComponent } from 'vue'
+import { GlobalMountOptions, RefSelector, Stub, Stubs } from './types'
+import {
+  Component,
+  ComponentOptions,
+  ConcreteComponent,
+  Directive,
+  FunctionalComponent
+} from 'vue'
 import { config } from './config'
 
 function mergeStubs(target: Record<string, any>, source: GlobalMountOptions) {
@@ -136,4 +142,40 @@ export function isRefSelector(
   selector: string | RefSelector
 ): selector is RefSelector {
   return typeof selector === 'object' && 'ref' in selector
+}
+
+export function convertStubsToRecord(stubs: Stubs) {
+  if (Array.isArray(stubs)) {
+    // ['Foo', 'Bar'] => { Foo: true, Bar: true }
+    return stubs.reduce((acc, current) => {
+      acc[current] = true
+      return acc
+    }, {} as Record<string, Stub>)
+  }
+
+  return stubs
+}
+
+const isDirectiveKey = (key: string) => key.match(/^v[A-Z].*/)
+
+export function getComponentsFromStubs(
+  stubs: Stubs
+): Record<string, Component | boolean> {
+  const normalizedStubs = convertStubsToRecord(stubs)
+
+  return Object.fromEntries(
+    Object.entries(normalizedStubs).filter(([key]) => !isDirectiveKey(key))
+  ) as Record<string, Component | boolean>
+}
+
+export function getDirectivesFromStubs(
+  stubs: Stubs
+): Record<string, Directive> {
+  const normalizedStubs = convertStubsToRecord(stubs)
+
+  return Object.fromEntries(
+    Object.entries(normalizedStubs)
+      .filter(([key]) => isDirectiveKey(key))
+      .map(([key, value]) => [key.substring(1), value])
+  ) as Record<string, Directive>
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -170,12 +170,12 @@ export function getComponentsFromStubs(
 
 export function getDirectivesFromStubs(
   stubs: Stubs
-): Record<string, Directive> {
+): Record<string, Directive | true> {
   const normalizedStubs = convertStubsToRecord(stubs)
 
   return Object.fromEntries(
     Object.entries(normalizedStubs)
-      .filter(([key]) => isDirectiveKey(key))
+      .filter(([key, value]) => isDirectiveKey(key) && value !== false)
       .map(([key, value]) => [key.substring(1), value])
   ) as Record<string, Directive>
 }

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -43,8 +43,6 @@ export function matches(
   const nodeTypeCandidates: VNodeTypes[] = [
     nodeType,
     getOriginalComponentFromStub(nodeType)
-    // getOriginalVNodeTypeFromStub(nodeType),
-    // getOriginalStubFromSpecializedStub(nodeType)
   ].filter(Boolean) as VNodeTypes[]
 
   // our selector might be a stub itself

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -5,11 +5,8 @@ import {
   VNodeNormalizedChildren,
   VNodeTypes
 } from 'vue'
+import { getOriginalComponentFromStub } from '../stubs'
 import { FindAllComponentsSelector } from '../types'
-import {
-  getOriginalStubFromSpecializedStub,
-  getOriginalVNodeTypeFromStub
-} from '../vnodeTransformers/stubComponentsTransformer'
 import { isComponent } from '../utils'
 import { matchName } from './matchName'
 import { unwrapLegacyVueExtendComponent } from './vueCompatSupport'
@@ -45,11 +42,15 @@ export function matches(
 
   const nodeTypeCandidates: VNodeTypes[] = [
     nodeType,
-    getOriginalVNodeTypeFromStub(nodeType),
-    getOriginalStubFromSpecializedStub(nodeType)
+    getOriginalComponentFromStub(nodeType)
+    // getOriginalVNodeTypeFromStub(nodeType),
+    // getOriginalStubFromSpecializedStub(nodeType)
   ].filter(Boolean) as VNodeTypes[]
 
-  if (nodeTypeCandidates.includes(selector)) {
+  // our selector might be a stub itself
+  const target = getOriginalComponentFromStub(selector) ?? selector
+
+  if (nodeTypeCandidates.includes(target)) {
     return true
   }
 

--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -10,18 +10,19 @@ import {
   ConcreteComponent,
   ComponentPropsOptions,
   ComponentObjectPropsOptions,
-  DefineComponent
+  DefineComponent,
+  Component
 } from 'vue'
 import { hyphenate } from '../utils/vueShared'
 import { matchName } from '../utils/matchName'
 import { isComponent, isFunctionalComponent } from '../utils'
 import { unwrapLegacyVueExtendComponent } from '../utils/vueCompatSupport'
-import { Stub, Stubs } from '../types'
 import {
   getComponentName,
   getComponentRegisteredName
 } from '../utils/componentName'
 import { config } from '../config'
+import { registerStub } from '../stubs'
 
 export type CustomCreateStub = (params: {
   name: string
@@ -33,30 +34,6 @@ interface StubOptions {
   type?: VNodeTypes | typeof Teleport
   renderStubDefaultSlot?: boolean
 }
-
-const stubsMap: WeakMap<
-  ConcreteComponent,
-  { source: ConcreteComponent; originalStub?: ConcreteComponent }
-> = new WeakMap()
-export const registerStub = ({
-  source,
-  stub,
-  originalStub
-}: {
-  source: ConcreteComponent
-  stub: ConcreteComponent
-  originalStub?: ConcreteComponent
-}) => {
-  stubsMap.set(stub, { source, originalStub })
-}
-
-export const getOriginalVNodeTypeFromStub = (
-  type: ConcreteComponent
-): VNodeTypes | undefined => stubsMap.get(type)?.source
-
-export const getOriginalStubFromSpecializedStub = (
-  type: ConcreteComponent
-): VNodeTypes | undefined => stubsMap.get(type)?.originalStub
 
 const doNotStubComponents: WeakSet<ConcreteComponent> = new WeakSet()
 const shouldNotStub = (type: ConcreteComponent) => doNotStubComponents.has(type)
@@ -112,15 +89,10 @@ export const createStub = ({
   })
 }
 
-const resolveComponentStubByName = (componentName: string, stubs: Stubs) => {
-  if (Array.isArray(stubs) && stubs.length) {
-    // ['Foo', 'Bar'] => { Foo: true, Bar: true }
-    stubs = stubs.reduce((acc, current) => {
-      acc[current] = true
-      return acc
-    }, {} as Record<string, Stub>)
-  }
-
+const resolveComponentStubByName = (
+  componentName: string,
+  stubs: Record<string, Component | boolean>
+) => {
   for (const [stubKey, value] of Object.entries(stubs)) {
     if (matchName(componentName, stubKey)) {
       return value
@@ -129,7 +101,7 @@ const resolveComponentStubByName = (componentName: string, stubs: Stubs) => {
 }
 
 interface CreateStubComponentsTransformerConfig {
-  stubs?: Stubs
+  stubs?: Record<string, Component | boolean>
   shallow?: boolean
   renderStubDefaultSlot: boolean
 }
@@ -153,7 +125,7 @@ export function createStubComponentsTransformer({
 
     // stub transition by default via config.global.stubs
     if (
-      (type === Transition || type === BaseTransition) &&
+      (type === Transition || (type as any) === BaseTransition) &&
       'transition' in stubs
     ) {
       if (stubs.transition === false) return type
@@ -166,7 +138,7 @@ export function createStubComponentsTransformer({
     }
 
     // stub transition-group by default via config.global.stubs
-    if (type === TransitionGroup && 'transition-group' in stubs) {
+    if ((type as any) === TransitionGroup && 'transition-group' in stubs) {
       if (stubs['transition-group'] === false) return type
 
       return createStub({
@@ -206,16 +178,17 @@ export function createStubComponentsTransformer({
     if (isComponent(stub)) {
       const unwrappedStub = unwrapLegacyVueExtendComponent(stub)
       const stubFn = isFunctionalComponent(unwrappedStub) ? unwrappedStub : null
+
+      // Edge case: stub is component, we will not render stub but instead will create
+      // a new "copy" of stub component definition, but we want user still to be able
+      // to find our component by stub definition, so we register it manually
+      registerStub({ source: type, stub })
+
       const specializedStubComponent: ConcreteComponent = stubFn
         ? (...args) => stubFn(...args)
         : { ...unwrappedStub }
       specializedStubComponent.props = unwrappedStub.props
 
-      registerStub({
-        source: type,
-        stub: specializedStubComponent,
-        originalStub: stub
-      })
       return specializedStubComponent
     }
 
@@ -241,7 +214,6 @@ export function createStubComponentsTransformer({
           type,
           renderStubDefaultSlot
         })
-      registerStub({ source: type, stub: newStub })
       return newStub
     }
 

--- a/src/vnodeTransformers/stubDirectivesTransformer.ts
+++ b/src/vnodeTransformers/stubDirectivesTransformer.ts
@@ -1,0 +1,46 @@
+import { Directive } from 'vue'
+import { isObjectComponent } from '../utils'
+import type { VTUVNodeTypeTransformer } from './util'
+
+interface CreateDirectivesTransformerConfig {
+  directives: Record<string, Directive | boolean>
+}
+
+const noop = () => {}
+export function createStubDirectivesTransformer({
+  directives = {}
+}: CreateDirectivesTransformerConfig): VTUVNodeTypeTransformer {
+  if (Object.keys(directives).length === 0) {
+    return (type) => type
+  }
+
+  return function directivesTransformer(type) {
+    if (isObjectComponent(type) && type.directives) {
+      const directivesToPatch = Object.keys(type.directives).filter(
+        (key) => key in directives
+      )
+
+      if (!directivesToPatch.length) {
+        return type
+      }
+
+      const replacementDirectives = Object.fromEntries(
+        directivesToPatch.map((name) => {
+          const directive = directives[name]
+
+          return [name, typeof directive === 'boolean' ? noop : directive]
+        })
+      )
+
+      return {
+        ...type,
+        directives: {
+          ...type.directives,
+          ...replacementDirectives
+        }
+      }
+    }
+
+    return type
+  }
+}

--- a/src/vnodeTransformers/stubDirectivesTransformer.ts
+++ b/src/vnodeTransformers/stubDirectivesTransformer.ts
@@ -3,7 +3,7 @@ import { isObjectComponent } from '../utils'
 import type { VTUVNodeTypeTransformer } from './util'
 
 interface CreateDirectivesTransformerConfig {
-  directives: Record<string, Directive | boolean>
+  directives: Record<string, Directive | true>
 }
 
 const noop = () => {}
@@ -16,6 +16,8 @@ export function createStubDirectivesTransformer({
 
   return function directivesTransformer(type) {
     if (isObjectComponent(type) && type.directives) {
+      // We want to change component types as rare as possible
+      // So first we check if there are any directives we should stub
       const directivesToPatch = Object.keys(type.directives).filter(
         (key) => key in directives
       )
@@ -36,6 +38,7 @@ export function createStubDirectivesTransformer({
         ...type,
         directives: {
           ...type.directives,
+          // let's add replacement directives on top of existing component directives
           ...replacementDirectives
         }
       }

--- a/src/vnodeTransformers/stubDirectivesTransformer.ts
+++ b/src/vnodeTransformers/stubDirectivesTransformer.ts
@@ -16,7 +16,7 @@ export function createStubDirectivesTransformer({
 
   return function directivesTransformer(type) {
     if (isObjectComponent(type) && type.directives) {
-      // We want to change component types as rare as possible
+      // We want to change component types as rarely as possible
       // So first we check if there are any directives we should stub
       const directivesToPatch = Object.keys(type.directives).filter(
         (key) => key in directives

--- a/src/vnodeTransformers/util.ts
+++ b/src/vnodeTransformers/util.ts
@@ -1,4 +1,5 @@
 import { isComponent } from '../utils'
+import { registerStub } from '../stubs'
 import { ConcreteComponent, transformVNodeArgs } from 'vue'
 
 type VNodeArgsTransformerFn = NonNullable<
@@ -9,8 +10,10 @@ type VNodeTransformerArgsType = TransformVNodeArgs[0]
 type InstanceArgsType = TransformVNodeArgs[1]
 type VNodeTransformerInputType = VNodeTransformerArgsType[0]
 
-type VNodeTransformerInputComponentType = VNodeTransformerInputType &
-  ConcreteComponent
+type ExtractComponentTypes<T> = T extends ConcreteComponent ? T : never
+
+type VNodeTransformerInputComponentType =
+  ExtractComponentTypes<VNodeTransformerInputType>
 
 export type VTUVNodeTypeTransformer = (
   inputType: VNodeTransformerInputComponentType,
@@ -45,7 +48,12 @@ export const createVNodeTransformer = ({
       (type, transformer) => transformer(type, instance),
       componentType
     )
-    transformationCache.set(originalType, transformedType)
+
+    if (originalType !== transformedType) {
+      transformationCache.set(originalType, transformedType)
+
+      registerStub({ source: originalType, stub: transformedType })
+    }
 
     return [transformedType, ...restVNodeArgs]
   }

--- a/tests/findComponent.spec.ts
+++ b/tests/findComponent.spec.ts
@@ -541,4 +541,24 @@ describe('findComponent', () => {
       ).toBe(true)
     })
   })
+
+  it('finds a component without name by its definition when stubbing directives', () => {
+    const ChildComponent = { template: 'child' }
+
+    const Component = defineComponent({
+      template: '<div><other-name /></div>',
+      components: {
+        OtherName: ChildComponent
+      }
+    })
+
+    const wrapper = mount(Component, {
+      global: {
+        stubs: {
+          vFakeDirective: {}
+        }
+      }
+    })
+    expect(wrapper.findComponent(ChildComponent).exists()).toBe(true)
+  })
 })

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -883,7 +883,7 @@ describe('mounting options: stubs', () => {
       expect(wrapper.classes()).toContain('DirectiveStubAdded')
     })
 
-    it('stubs directive as noop', () => {
+    it('stubs directive as noop when true passed as value', () => {
       const SomeDirective = () => {
         throw new Error('I will blow up!')
       }
@@ -902,6 +902,23 @@ describe('mounting options: stubs', () => {
       })
 
       expect(wrapper.html()).toBe('<div>text</div>')
+    })
+
+    it('does not stub directive as noop when false passed as value', () => {
+      const Component = {
+        template: '<div v-my-directive>text</div>',
+        directives: { MyDirective }
+      }
+
+      const wrapper = mount(Component, {
+        global: {
+          stubs: {
+            vMyDirective: false
+          }
+        }
+      })
+
+      expect(wrapper.html()).toBe('<div class="DirectiveAdded">text</div>')
     })
 
     it('stubs directive on child component', () => {

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { h, defineComponent, defineAsyncComponent } from 'vue'
-
+import { h, defineComponent, defineAsyncComponent, Directive } from 'vue'
 import { config, flushPromises, mount, RouterLinkStub } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'
@@ -852,5 +851,106 @@ describe('mounting options: stubs', () => {
     const stubAfterSecondRender = wrapper.findComponent({ name: 'FooBar' })
 
     expect(stub.vm).toBe(stubAfterSecondRender.vm)
+  })
+
+  describe('directives', () => {
+    const MyDirective: Directive = {
+      beforeMount(el: Element) {
+        el.classList.add('DirectiveAdded')
+      }
+    }
+
+    const MyDirectiveStub: Directive = {
+      beforeMount(el: Element) {
+        el.classList.add('DirectiveStubAdded')
+      }
+    }
+
+    it('stubs directive on root component', () => {
+      const Component = {
+        template: '<div v-my-directive>text</div>',
+        directives: { MyDirective }
+      }
+
+      const wrapper = mount(Component, {
+        global: {
+          stubs: {
+            vMyDirective: MyDirectiveStub
+          }
+        }
+      })
+
+      expect(wrapper.classes()).toContain('DirectiveStubAdded')
+    })
+
+    it('stubs directive as noop', () => {
+      const SomeDirective = () => {
+        throw new Error('I will blow up!')
+      }
+
+      const Component = {
+        template: '<div v-some-directive>text</div>',
+        directives: { SomeDirective }
+      }
+
+      const wrapper = mount(Component, {
+        global: {
+          stubs: {
+            vSomeDirective: true
+          }
+        }
+      })
+
+      expect(wrapper.html()).toBe('<div>text</div>')
+    })
+
+    it('stubs directive on child component', () => {
+      const Component = {
+        template: '<div v-my-directive>text</div>',
+        directives: { MyDirective }
+      }
+
+      const RootComponent = {
+        components: { ChildComponent: Component },
+        template: '<div><child-component class="child" /></div>'
+      }
+
+      const wrapper = mount(RootComponent, {
+        global: {
+          stubs: {
+            vMyDirective: MyDirectiveStub
+          }
+        }
+      })
+
+      expect(wrapper.find('.child').classes()).toContain('DirectiveStubAdded')
+    })
+
+    it('stubs directive on root component with script setup', () => {
+      const Component = {
+        setup() {
+          // @ts-ignore-error (directive used by script setup)
+          const vMyDirective = MyDirective
+        },
+        template: '<div v-my-directive>text</div>',
+        directives: { MyDirective }
+      }
+
+      const MyDirectiveStub: Directive = {
+        beforeMount(el: Element) {
+          el.classList.add('DirectiveStubAdded')
+        }
+      }
+
+      const wrapper = mount(Component, {
+        global: {
+          stubs: {
+            vMyDirective: MyDirectiveStub
+          }
+        }
+      })
+
+      expect(wrapper.classes()).toContain('DirectiveStubAdded')
+    })
   })
 })


### PR DESCRIPTION
We're adding new vnode transformer (related to directives) and re-use our architecture for searching stubs to make sure that we still could find elements even after stubbing directives on them

