### PR TITLE
chore(scripts): add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "test:build": "vitest --mode test-build",
     "tsd": "tsc -p test-dts/tsconfig.tsd.json",
     "build": "rollup -c rollup.config.js",
+    "prepare": "rollup -c rollup.config.js",
     "lint": "eslint --ext .ts src/ tests/",
     "lint:fix": "pnpm run lint --fix",
     "docs:dev": "vitepress dev docs",


### PR DESCRIPTION
This is extremely simple, yet useful (in my opinion) change.

> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.

Since npm v5 npm executes `prepare` script when dependency is installed from git. By including `prepare` script it will allow our users use `@vue/test-utils` from `main` (or any other branch) even if release was not published to npm yet

However, this has a downside - after doing install locally (without include `@vue/test-utils` as dependency) it will be also executed. However, I feel here benefits outweight the downside

WDYT?