### PR TITLE
fix(stubs): Do not render function body in stub

### DIFF
--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -274,6 +274,22 @@ describe('props', () => {
     expect(wrapper.text()).toEqual('hello')
   })
 
+  it('stub function props when shallow mounting', () => {
+    const Comp = defineComponent({
+      name: 'Comp',
+      template: `<div>Test</div>`,
+      props: ['fn']
+    })
+
+    const wrapper = shallowMount({
+      render() {
+        return h(Comp, { fn: () => {} })
+      }
+    })
+
+    expect(wrapper.html()).toBe('<comp-stub fn="[Function]"></comp-stub>')
+  })
+
   describe('edge case with symbol props and stubs', () => {
     it('works with Symbol as default', () => {
       const Comp = defineComponent({


### PR DESCRIPTION
`@vue/test-utils` v1 had special handing for functions in props when rendering stubs. 

This PR makes `@vue/test-utils` v2 behave in the same way, even reusing same placeholder from https://github.com/vuejs/vue-test-utils/blob/97fdf18cd96f2ce19036d497ec98f2f76fc7b066/packages/create-instance/create-component-stubs.js#L21

(this allows us to run snaphot tests of vue2 and `@vue/compat` and to verify snapshots identity)