### PR TITLE
chore: update to vitest v0.24.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "unplugin-vue-components": "0.22.8",
     "vite": "3.1.8",
     "vitepress": "0.22.4",
-    "vitest": "0.22.1",
+    "vitest": "0.24.3",
     "vue": "3.2.41",
     "vue-class-component": "8.0.0-rc.1",
     "vue-router": "4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ specifiers:
   unplugin-vue-components: 0.22.8
   vite: 3.1.8
   vitepress: 0.22.4
-  vitest: 0.22.1
+  vitest: 0.24.3
   vue: 3.2.41
   vue-class-component: 8.0.0-rc.1
   vue-router: 4.1.5
@@ -75,7 +75,7 @@ devDependencies:
   unplugin-vue-components: 0.22.8_vue@3.2.41
   vite: 3.1.8
   vitepress: 0.22.4
-  vitest: 0.22.1_jsdom@20.0.1
+  vitest: 0.24.3_jsdom@20.0.1
   vue: 3.2.41
   vue-class-component: 8.0.0-rc.1_vue@3.2.41
   vue-router: 4.1.5_vue@3.2.41
@@ -3468,6 +3468,12 @@ packages:
       acorn: 8.8.0
     dev: true
 
+  /strip-literal/0.4.2:
+    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
+    dependencies:
+      acorn: 8.8.0
+    dev: true
+
   /supports-color/5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -3517,8 +3523,17 @@ packages:
     engines: {node: '>=16.0.0'}
     dev: true
 
+  /tinybench/2.3.1:
+    resolution: {integrity: sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==}
+    dev: true
+
   /tinypool/0.2.4:
     resolution: {integrity: sha512-Vs3rhkUH6Qq1t5bqtb816oT+HeJTXfwt2cbPH17sWHIYKTotQIFPk3tf2fgqRrVyMDVOc1EnPgzIxfIulXVzwQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinypool/0.3.0:
+    resolution: {integrity: sha512-NX5KeqHOBZU6Bc0xj9Vr5Szbb1j8tUHIeD18s41aDJaPeC5QTdEhK0SpdpUrZlj2nv5cctNcSjaKNanXlfcVEQ==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -3753,46 +3768,6 @@ packages:
       - stylus
     dev: true
 
-  /vitest/0.22.1_jsdom@20.0.1:
-    resolution: {integrity: sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==}
-    engines: {node: '>=v14.16.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/chai': 4.3.3
-      '@types/chai-subset': 1.3.3
-      '@types/node': 18.0.6
-      chai: 4.3.6
-      debug: 4.3.4
-      jsdom: 20.0.1
-      local-pkg: 0.4.2
-      tinypool: 0.2.4
-      tinyspy: 1.0.2
-      vite: 3.1.8
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - supports-color
-      - terser
-    dev: true
-
   /vitest/0.23.0_jsdom@20.0.1:
     resolution: {integrity: sha512-I3ctlfiXYprA2tID1qP+m6pmgmKx3HYfRe66MetGOHKCHLY7hz74ihiwIEtN7LReJgF3U5cM735iYPkn/Go1iQ==}
     engines: {node: '>=v14.16.0'}
@@ -3825,6 +3800,48 @@ packages:
       strip-literal: 0.4.0
       tinybench: 2.1.4
       tinypool: 0.2.4
+      tinyspy: 1.0.2
+      vite: 3.1.8
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest/0.24.3_jsdom@20.0.1:
+    resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.3
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.0.6
+      chai: 4.3.6
+      debug: 4.3.4
+      jsdom: 20.0.1
+      local-pkg: 0.4.2
+      strip-literal: 0.4.2
+      tinybench: 2.3.1
+      tinypool: 0.3.0
       tinyspy: 1.0.2
       vite: 3.1.8
     transitivePeerDependencies:

--- a/tests/features/compat.spec.ts
+++ b/tests/features/compat.spec.ts
@@ -3,7 +3,7 @@ import * as mockVue from '@vue/compat'
 import { mount } from '../../src'
 
 vi.mock('vue', () => mockVue)
-const { configureCompat, extend, defineComponent, h } = mockVue
+const { configureCompat, defineComponent, h } = mockVue
 // @ts-expect-error @vue/compat does not expose default export in types
 const Vue = mockVue.default
 
@@ -46,7 +46,7 @@ describe('@vue/compat build', () => {
   it('finds components declared with legacy Vue.extend', () => {
     configureCompat({ MODE: 3, GLOBAL_EXTEND: 'suppress-warning' })
 
-    const LegacyComponent = extend({
+    const LegacyComponent = Vue.extend({
       template: '<div>LEGACY</div>'
     })
 
@@ -97,7 +97,7 @@ describe('@vue/compat build', () => {
       COMPONENT_FUNCTIONAL: 'suppress-warning'
     })
 
-    const Component = extend({
+    const Component = Vue.extend({
       functional: true,
       render: () => h('div', 'test')
     })
@@ -112,7 +112,7 @@ describe('@vue/compat build', () => {
       GLOBAL_EXTEND: 'suppress-warning'
     })
 
-    const Foo = extend({
+    const Foo = Vue.extend({
       name: 'Foo',
       template: '<div>original</div>'
     })
@@ -147,7 +147,7 @@ describe('@vue/compat build', () => {
       template: '<div>original</div>'
     }
 
-    const FooStub = extend({ template: '<div>stubbed</div>' })
+    const FooStub = Vue.extend({ template: '<div>stubbed</div>' })
 
     const Component = {
       components: { NamedAsNotFoo: Foo },
@@ -172,7 +172,7 @@ describe('@vue/compat build', () => {
       GLOBAL_MOUNT: 'suppress-warning'
     })
 
-    const Component = extend({
+    const Component = Vue.extend({
       data() {
         return { foo: 'bar' }
       },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
   },
   resolve: {
     extensions: ['.vue', '.js', '.json', '.jsx', '.ts', '.tsx', '.node'],
-    dedupe: ['vue', '@vue/compat']
+    dedupe: ['vue', '@vue/compat'],
+    alias: {
+      '@vue/compat': '@vue/compat/dist/vue.esm-bundler.js'
+    }
   }
 })


### PR DESCRIPTION
We were blocked by https://github.com/vitest-dev/vitest/issues/1978 but thanks to @sheremet-va help (see https://github.com/vitest-dev/vitest/issues/1978#issuecomment-1283747642) we now have a way to use the latest vitest releases.

It turns out that we needed to:
- alias `@vue/compat` to its ESM bundle
- use `Vue.extend` instead of `extend` in the `compat.spec.ts` file, as `extend` is not a named export