### PR TITLE
fix(stubs): teleport stub children as a function

### DIFF
--- a/tests/element.spec.ts
+++ b/tests/element.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 
 import { mount } from '../src'
@@ -107,6 +107,7 @@ describe('element', () => {
   })
 
   it('returns correct element for component which renders other component with array of vnodes in default slot', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const Nested = {
       template: '<div class="nested-root"><slot></slot></div>'
     }
@@ -114,5 +115,9 @@ describe('element', () => {
 
     const wrapper = mount(Root)
     expect(wrapper.element.innerHTML).toBe('<div>foo</div><div>bar</div>')
+    // we're expecting a warning from Vue as we're using non-function slots
+    expect(spy.mock.calls[0][0]).toContain(
+      'Non-function value encountered for default slot'
+    )
   })
 })

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 import { DefineComponent, defineComponent, h } from 'vue'
@@ -100,6 +100,7 @@ describe('findAllComponents', () => {
   })
 
   it('findAllComponents with non-function slots', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const ComponentA = defineComponent({
       template: '<div><slot /></div>'
     })
@@ -119,5 +120,9 @@ describe('findAllComponents', () => {
     })
     expect(wrapper.findAll('span')).toHaveLength(3)
     expect(wrapper.findAllComponents(ComponentB)).toHaveLength(3)
+    // we're expecting a warning from Vue as we're using non-function slots
+    expect(spy.mock.calls[0][0]).toContain(
+      'Non-function value encountered for default slot'
+    )
   })
 })

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -512,6 +512,7 @@ describe('mounting options: stubs', () => {
     })
 
     it('opts in to stubbing teleport ', () => {
+      const spy = vi.spyOn(console, 'warn')
       const Comp = {
         template: `<teleport to="body"><div id="content" /></teleport>`
       }
@@ -528,6 +529,9 @@ describe('mounting options: stubs', () => {
           '  <div id="content"></div>\n' +
           '</teleport-stub>'
       )
+      // Make sure that we don't have a warning when stubbing teleport
+      // https://github.com/vuejs/test-utils/issues/1829
+      expect(spy).not.toHaveBeenCalled()
     })
 
     it('does not stub teleport with shallow', () => {


### PR DESCRIPTION
Fixes #1829

I'm not super convinced by this fix, but it indeed looks like @freakzlike intuition is right: we need to return the children as a function for Teleport to avoid the warning.

Maybe @xanf you have a better idea on how to handle that?