### PR TITLE
chore: update to js-beautify v1.14.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.2.1",
     "husky": "8.0.1",
-    "js-beautify": "1.14.6",
+    "js-beautify": "1.14.7",
     "jsdom": "20.0.1",
     "jsdom-global": "3.0.2",
     "lint-staged": "13.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ specifiers:
   eslint-config-prettier: 8.5.0
   eslint-plugin-prettier: 4.2.1
   husky: 8.0.1
-  js-beautify: 1.14.6
+  js-beautify: 1.14.7
   jsdom: 20.0.1
   jsdom-global: 3.0.2
   lint-staged: 13.0.3
@@ -63,7 +63,7 @@ devDependencies:
   eslint-config-prettier: 8.5.0_eslint@8.25.0
   eslint-plugin-prettier: 4.2.1_hvbqyfstm4urdpm6ffpwfka4e4
   husky: 8.0.1
-  js-beautify: 1.14.6
+  js-beautify: 1.14.7
   jsdom: 20.0.1
   jsdom-global: 3.0.2_jsdom@20.0.1
   lint-staged: 13.0.3
@@ -2673,8 +2673,8 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
-  /js-beautify/1.14.6:
-    resolution: {integrity: sha512-GfofQY5zDp+cuHc+gsEXKPpNw2KbPddreEo35O6jT6i0RVK6LhsoYBhq5TvK4/n74wnA0QbK8gGd+jUZwTMKJw==}
+  /js-beautify/1.14.7:
+    resolution: {integrity: sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
The following commit in js-beautify introduced a breaking change for us, as custom element are now treated as inline elements https://github.com/beautify-web/js-beautify/commit/aa82eb9ce664abadbcb454fd7a3a4d8de53dddec

This means a bunch of our tests, and snapshots of our users, break with this new version.

What do you think we should do?
- lock the version of js-beautify for ever to v1.14.6
- bump to v1.1.4.7, update our tests, and warn our users about the breaking change
- talk about this with the js-beautify team and see if that should be configurable maybe?