### PR TITLE
fix(mount): correctly work with component throwing on mount

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -574,8 +574,23 @@ export function mount(
     }
   }
 
+  // Workaround for https://github.com/vuejs/core/issues/7020
+  const originalErrorHandler = app.config.errorHandler
+
+  let errorOnMount = null
+  app.config.errorHandler = (err, instance, info) => {
+    errorOnMount = err
+
+    return originalErrorHandler?.(err, instance, info)
+  }
+
   // mount the app!
   const vm = app.mount(el)
+
+  if (errorOnMount) {
+    throw errorOnMount
+  }
+  app.config.errorHandler = originalErrorHandler
 
   const appRef = componentRef.value! as ComponentPublicInstance
   // we add `hasOwnProperty` so Jest can spy on the proxied vm without throwing

--- a/tests/mount.spec.ts
+++ b/tests/mount.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+import { mount } from '../src'
+
+describe('mount: general tests', () => {
+  it('correctly handles component, throwing on mount', () => {
+    // See https://github.com/vuejs/core/issues/7020
+    const ThrowingComponent = defineComponent({
+      props: ['blowup'],
+      mounted() {
+        if (this.blowup) {
+          throw new Error('Boom!')
+        }
+      },
+      template: '<div>hello</div>'
+    })
+
+    expect(() =>
+      mount(ThrowingComponent, { props: { blowup: true } })
+    ).toThrow()
+
+    const wrapper = mount(ThrowingComponent, { props: { blowup: false } })
+
+    expect(wrapper.html()).toBe('<div>hello</div>')
+  })
+})


### PR DESCRIPTION
This is a workaround for https://github.com/vuejs/core/issues/7020

VTU v1, obviously do not blow up in this case