### PR TITLE
fix(emit): force event handling even with fake timers

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -369,6 +369,13 @@ export default abstract class BaseWrapper<ElementType extends Node>
 
     if (this.element && !this.isDisabled()) {
       const event = createDOMEvent(eventString, options)
+      // see https://github.com/vuejs/test-utils/issues/1854
+      // fakeTimers provoke an issue as Date.now() always return the same value
+      // and Vue relies on it to determine if the handler should be invoked
+      // see https://github.com/vuejs/core/blob/5ee40532a63e0b792e0c1eccf3cf68546a4e23e9/packages/runtime-dom/src/modules/events.ts#L100-L104
+      // we workaround this issue by manually setting _vts to Date.now() + 1
+      // thus making sure the event handler is invoked
+      event._vts = Date.now() + 1
       this.element.dispatchEvent(event)
     }
 

--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -364,4 +364,31 @@ describe('trigger', () => {
 
     expect(wrapper.emitted().enter).toHaveLength(1)
   })
+
+  // https://github.com/vuejs/test-utils/issues/1854
+  it('dispatches events even with fakeTimers', async () => {
+    const handlerSpy = vi.fn()
+
+    const Component = defineComponent({
+      setup() {
+        return { handlerSpy }
+      },
+      template: `
+      <div>
+        <a @click="handlerSpy">
+          <span @click="() => {}">Ok</span>
+        </a>
+      </div>
+      `
+    })
+
+    vi.useFakeTimers()
+    const wrapper = mount(Component)
+
+    expect(handlerSpy).not.toHaveBeenCalled()
+
+    await wrapper.get('span').trigger('click')
+
+    expect(handlerSpy).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Fixes #1854

I'm not 100% convinced this is the proper way to fix it, but I don't have a better idea at the moment.
Setting `_vts` to Date.now() + 1 tricks Vue into thinking it has to handle the event even if `Date.now()` is faked and always returns the same value https://github.com/vuejs/core/blob/5ee40532a63e0b792e0c1eccf3cf68546a4e23e9/packages/runtime-dom/src/modules/events.ts#L100-L104

I hope this doesn't introduce other subtle issues. It would be great to only do this if the test is running with a fake Date, but I don't know how we can find out reliably for jest or vitest or even a manually mocked Date object.