### PR TITLE
refactor: use a proxy for wrapper.vm

### DIFF
--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
 import DefineExpose from './components/DefineExpose.vue'
@@ -54,5 +55,10 @@ describe('expose', () => {
     // can access `count` even if it is _not_ exposed
     // @ts-ignore we need better types here, see https://github.com/vuejs/test-utils/issues/972
     expect(wrapper.vm.count).toBe(1)
+
+    // @ts-ignore we need better types here, see https://github.com/vuejs/test-utils/issues/972
+    wrapper.vm.count = 2
+    await nextTick()
+    expect(wrapper.html()).toContain('2')
   })
 })


### PR DESCRIPTION
This fixes the issues with Vue v3.2.45 (see https://github.com/vuejs/core/issues/7103)