### PR TITLE
fix: allow spying on non-exposed script setup functions

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -45,11 +45,28 @@ function createVMProxy<T extends ComponentPublicInstance>(
         return Reflect.set(vm, key, value, receiver)
       }
     },
+    has(vm, property) {
+      return Reflect.has(setupState, property) || Reflect.has(vm, property)
+    },
+    defineProperty(vm, key, attributes) {
+      if (key in setupState) {
+        return Reflect.defineProperty(setupState, key, attributes)
+      } else {
+        return Reflect.defineProperty(vm, key, attributes)
+      }
+    },
     getOwnPropertyDescriptor(vm, property) {
       if (property in setupState) {
         return Reflect.getOwnPropertyDescriptor(setupState, property)
       } else {
         return Reflect.getOwnPropertyDescriptor(vm, property)
+      }
+    },
+    deleteProperty(vm, property) {
+      if (property in setupState) {
+        return Reflect.deleteProperty(setupState, property)
+      } else {
+        return Reflect.deleteProperty(vm, property)
       }
     }
   })

--- a/tests/components/ScriptSetup.vue
+++ b/tests/components/ScriptSetup.vue
@@ -12,6 +12,6 @@ const inc = () => {
 </script>
 
 <template>
-  <button @click="inc">{{ count }}</button>
+  <button @click="inc()">{{ count }}</button>
   <Hello />
 </template>

--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
@@ -60,5 +60,20 @@ describe('expose', () => {
     wrapper.vm.count = 2
     await nextTick()
     expect(wrapper.html()).toContain('2')
+  })
+
+  it('spies on vm with <script setup> even without defineExpose()', async () => {
+    const wrapper = mount(ScriptSetup)
+
+    const spiedIncrement = vi
+      // @ts-ignore we need better types here, see https://github.com/vuejs/test-utils/issues/972
+      .spyOn(wrapper.vm, 'inc')
+      .mockImplementation(() => {})
+
+    await wrapper.find('button').trigger('click')
+    await nextTick()
+
+    expect(spiedIncrement).toHaveBeenCalled()
+    expect(wrapper.html()).toContain('0')
   })
 })


### PR DESCRIPTION
Fixes #1859

The proxy needs to implement `defineProperty` to allow spying.