### PR TITLE
[docs]: improve slot scope auto exposing "params" behaviour

### DIFF
--- a/docs/guide/advanced/slots.md
+++ b/docs/guide/advanced/slots.md
@@ -139,7 +139,7 @@ test('layout full page layout', () => {
 
 ## Scoped Slots
 
-[Scoped slots](https://v3.vuejs.org/guide/component-slots.html#scoped-slots) and bindings are also supported.
+[Scoped slots](https://v3.vuejs.org/guide/component-slots.html#scoped-slots) and bindings are also supported. 
 
 ```js
 const ComponentWithSlots = {
@@ -158,8 +158,8 @@ const ComponentWithSlots = {
 test('scoped slots', () => {
   const wrapper = mount(ComponentWithSlots, {
     slots: {
-      scoped: `<template #scoped="params">
-        Hello {{ params.msg }}
+      scoped: `<template #scoped="scope">
+        Hello {{ scope.msg }}
         </template>
       `
     }
@@ -168,6 +168,19 @@ test('scoped slots', () => {
   expect(wrapper.html()).toContain('Hello world')
 })
 ```
+
+When using string templates for slot content, **if not explicitly defined using a wrapping `<template #scoped="scopeVar">` tag**, slot scope becomes available as a `params` object when the slot is evaluated.
+
+```js
+test('scoped slots', () => {
+  const wrapper = mount(ComponentWithSlots, {
+    slots: {
+      scoped: `Hello {{ params.msg }}` // no wrapping template tag provided, slot scope exposed as "params"
+    }
+  })
+
+  expect(wrapper.html()).toContain('Hello world')
+})
 
 ## Conclusion
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -217,6 +217,20 @@ Vue 3 renamed the `vm.$destroy` to `vm.$unmount`. Vue Test Utils has followed su
 
 Vue 3 united the `slot` and `scoped-slot` syntax under a single syntax, `v-slot`, which you can read about in the [the docs](https://v3.vuejs.org/guide/migration/slots-unification.html#overview). Since `slot` and `scoped-slot` are now merged, the `scopedSlots` mounting option is now deprecated - just use the `slots` mounting option for everything.
 
+### `slots`‘s scope is now exposed as `params`
+
+When using string templates for slot content, if not explicitly defined using a wrapping `<template #slot-name="scopeVar">` tag, slot scope becomes available as a `params` object when the slot is evaluated.
+
+```diff
+shallowMount(Component, {
+-  scopedSlots: {
++  slots: {
+-    default: '<p>{{props.index}},{{props.text}}</p>'
++    default: '<p>{{params.index}},{{params.text}}</p>'
+  }
+})
+````
+
 ### `findAll().at()` removed
 
 `findAll()` now returns an array of DOMWrappers.


### PR DESCRIPTION
Hello again 👋 
I had a bunch of specs that rely on the previous VTU1 behaviour, where slot scope was auto-exposed as a `props` object for string templates and realised that in VTU2 they are exposed as `params`

https://github.com/vuejs/test-utils/blob/39d86ad5abe71bac8d76c5b82f11f30225cf8673/src/utils/compileSlots.ts#L9-L11

While VTU1 docs [mention](https://v1.test-utils.vuejs.org/api/options.html#scopedslots) that behaviour, VTU2 docs [didn't **explicitly** do it](https://test-utils.vuejs.org/guide/advanced/slots.html#scoped-slots) as the only example provided used an `<template #scope="params">` which doesn't document the implicit behaviour if not providing a wrapping `<template>` tag.

Update both main docs and migration guide, since I believe this is a common _bump in the road_ while migrating codebases.

As always feel free to edit the writing style and examples to suite the rest of the docs.
Cheers ✌️ 