### PR TITLE
[docs]: fix broken  slots documentation

### DIFF
--- a/docs/guide/advanced/slots.md
+++ b/docs/guide/advanced/slots.md
@@ -181,6 +181,7 @@ test('scoped slots', () => {
 
   expect(wrapper.html()).toContain('Hello world')
 })
+```
 
 ## Conclusion
 


### PR DESCRIPTION
The last change broke the conclusion section.