### PR TITLE
[docs]: remove duplicate sentence

### DIFF
--- a/docs/guide/essentials/easy-to-test.md
+++ b/docs/guide/essentials/easy-to-test.md
@@ -28,7 +28,7 @@ Notice how this list does not include elements such as internal methods, interme
 
 The rule of thumb is that **a test should not break on a refactor**, that is, when we change its internal implementation without changing its behavior. If that happens, the test might rely on implementation details.
 
-For example, let's assume a basic Counter component that features a button to increment a counter. We could write the following test:
+For example, let's assume a basic Counter component that features a button to increment a counter:
 
 ```vue
 <template>


### PR DESCRIPTION
| Just fixing this issue with the docs: |
|:-:|
| ![image](https://user-images.githubusercontent.com/811806/211543987-012a3125-7ef9-41ee-83e7-2d15c1f937bf.png) |


| Before | After |
|:-:|:-:|
| ![image](https://user-images.githubusercontent.com/811806/211543666-80816f9c-2f58-45ad-bfb9-c0444d9419c1.png) | ![image](https://user-images.githubusercontent.com/811806/211543772-43fdc552-ce4a-4784-a0bd-73e3d6e15ecf.png) |

