### PR TITLE
feat: add support for input with max-length prop

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -117,6 +117,10 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
       }
       return this.trigger('change')
     } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+      if (
+        element.hasAttribute('maxlength') &&
+        element.maxLength < value
+      ) value = value.slice(0, element.maxLength);
       element.value = value
 
       this.trigger('input')

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -117,10 +117,8 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
       }
       return this.trigger('change')
     } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
-      if (
-        element.hasAttribute('maxlength') &&
-        element.maxLength < value
-      ) value = value.slice(0, element.maxLength);
+      if (element.hasAttribute('maxlength') && element.maxLength < value)
+        value = value.slice(0, element.maxLength)
       element.value = value
 
       this.trigger('input')

--- a/tests/components/ComponentWithInput.vue
+++ b/tests/components/ComponentWithInput.vue
@@ -14,6 +14,7 @@
       value="radioBarResult"
     />
     <input type="text" v-model="textVal" />
+    <input type="text" maxlength="5" v-model="textValWithMaxLength" />
     <input id="lazy" type="text" v-model.lazy="lazy" />
     <textarea v-model="textareaVal"></textarea>
     <select v-model="selectVal">
@@ -57,6 +58,7 @@ export default defineComponent({
     return {
       checkboxVal: undefined,
       textVal: undefined,
+      textValWithMaxLength: undefined,
       lazy: undefined,
       textareaVal: undefined,
       radioVal: undefined,

--- a/tests/setValue.spec.ts
+++ b/tests/setValue.spec.ts
@@ -15,6 +15,13 @@ describe('setValue', () => {
       expect(input.element.value).toBe('foo')
     })
 
+    it('slice value, when input el has maxLength prop', () => {
+      const wrapper = mount(ComponentWithInput)
+      const input = wrapper.find<HTMLInputElement>('input[maxlength="5"]')
+      input.setValue('123456')
+      expect(input.element.value).toBe('12345')
+    })
+
     it('sets element of textarea value', async () => {
       const wrapper = mount(ComponentWithInput)
       const textarea = wrapper.find<HTMLTextAreaElement>('textarea')


### PR DESCRIPTION
Inherited problem from v1, - https://github.com/vuejs/vue-test-utils/issues/1864
This PR solve this issue and add support for max-length prop for input include tests