### PR TITLE
fix: return wrapper error from DOMWrapper ctor if element is nullish

### DIFF
--- a/docs/guide/extending-vtu/plugins.md
+++ b/docs/guide/extending-vtu/plugins.md
@@ -109,11 +109,7 @@ const DataTestIdPlugin = (wrapper) => {
   function findByTestId(selector) {
     const dataSelector = `[data-testid='${selector}']`
     const element = wrapper.element.querySelector(dataSelector)
-    if (element) {
-      return new DOMWrapper(element)
-    }
-
-    return createWrapperError('DOMWrapper')
+    return new DOMWrapper(element)
   }
 
   return {

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -11,7 +11,10 @@ import { isRefSelector } from './utils'
 import { createWrapperError } from './errorWrapper'
 
 export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
-  constructor(element: NodeType) {
+  constructor(element: NodeType | null | undefined) {
+    if (!element) {
+      return createWrapperError('DOMWrapper')
+    }
     super(element)
     // plugins hook
     config.plugins.DOMWrapper.extend(this)

--- a/src/wrapperFactory.ts
+++ b/src/wrapperFactory.ts
@@ -7,7 +7,9 @@ export enum WrapperType {
   VueWrapper
 }
 
-type DOMWrapperFactory = <T extends Node>(element: T) => DOMWrapperType<T>
+type DOMWrapperFactory = <T extends Node>(
+  element: T | null | undefined
+) => DOMWrapperType<T>
 type VueWrapperFactory = <T extends ComponentPublicInstance>(
   app: App | null,
   vm: T,

--- a/tests/exists.spec.ts
+++ b/tests/exists.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { h, defineComponent } from 'vue'
 
-import { mount } from '../src'
+import { DOMWrapper, mount } from '../src'
 
 describe('exists', () => {
   it('returns false when element does not exist', () => {
@@ -49,5 +49,10 @@ describe('exists', () => {
     const child = wrapper.findComponent(ChildComponent)
     await wrapper.setProps({ hide: true })
     expect(child.exists()).toBe(false)
+  })
+
+  it('returns false when wrapper is manually constructed against nullish element', () => {
+    const wrapper = new DOMWrapper(null)
+    expect(wrapper.exists()).toBe(false)
   })
 })


### PR DESCRIPTION
fixes #1984 

Rationale: Rather than overriding `exists` on DomWrapper, I elected to instead return a wrapper error from DomWrapper's ctor if the provided element is nullish. 

This allows the ctor of DomWrapper to be changed to allow `null | undefined` without having to propagate `null | undefined` downwards into `BaseWrapper.constructor`, `BaseWrapper.wrapperElement`, `BaseWrapper.element`, and `WrapperLike.element`, a change that would be significantly breaking and cause consumers of test-utils to have to add non-null assertions all over the place.

This also simplifies some other uses cases, like for example the one I changed in plugins.md.