### PR TITLE
Fix propsData deprecation suggestion

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface MountingOptions<Props, Data = {}> {
    */
   props?: (RawProps & Props) | ({} extends Props ? null : never)
   /**
-   * @deprecated use `data` instead.
+   * @deprecated use `props` instead.
    */
   propsData?: Props
   /**


### PR DESCRIPTION
At the moment it suggests to use `data` instead of `propsData` but that does not work and just seems straight up wrong. It seems obvious to me it should be suggesting to use `props` instead since that actually works..