### PR TITLE
export ComponentMountingOptions to resolve type definetions in testing script by user

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,5 @@ export {
   MountingOptions,
   createWrapperError
 }
+
+export type { ComponentMountingOptions } from './mount'

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -26,7 +26,7 @@ import { createInstance } from './createInstance'
 // NOTE this should come from `vue`
 type PublicProps = VNodeProps & AllowedComponentProps & ComponentCustomProps
 
-type ComponentMountingOptions<T> = T extends DefineComponent<
+export type ComponentMountingOptions<T> = T extends DefineComponent<
   infer PropsOrPropOptions,
   any,
   infer D,


### PR DESCRIPTION
export ComponentMountingOptions to resolve type definetions in testing script by user.

demo like bllow
```typescript
import { mount， ComponentMountingOptions } from '@vue/test-utils';
import Tree from '../src/Tree.vue'; // Tree is a component.

type MountingOptionsTree = ComponentMountingOptions<typeof Tree>;  // Note this line

function getTreeWrap(
  props: MountingOptionsTree['props'] = {},
  options: MountingOptionsTree = {}
) {
  return mount(Tree, {
    props: {
      count: 1,
      ...props,
    },
    attachTo: 'body',
    ...options,
  })
}
```