### PR TITLE
fix(setValue): trigger input event for checkbox, radio and select

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -93,6 +93,7 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
     }
 
     element.checked = checked
+    this.trigger('input')
     return this.trigger('change')
   }
 
@@ -118,6 +119,8 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
       } else {
         element.value = value
       }
+
+      this.trigger('input')
       return this.trigger('change')
     } else if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
       element.value = value
@@ -146,7 +149,9 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
       parentElement = parentElement.parentElement!
     }
 
-    return new DOMWrapper(parentElement).trigger('change')
+    const parentWrapper = new DOMWrapper(parentElement)
+    parentWrapper.trigger('input')
+    return parentWrapper.trigger('change')
   }
 }
 

--- a/tests/setValue.spec.ts
+++ b/tests/setValue.spec.ts
@@ -33,6 +33,11 @@ describe('setValue', () => {
   })
 
   describe('on select and option', () => {
+    const renderOptions = () => [
+      h('option', { value: 'A' }),
+      h('option', { value: 'B' })
+    ]
+
     it('sets element of select value', async () => {
       const wrapper = mount(ComponentWithInput)
       const select = wrapper.find<HTMLSelectElement>('select')
@@ -42,7 +47,7 @@ describe('setValue', () => {
       expect(wrapper.text()).toContain('selectB')
 
       expect(wrapper.emitted('change')).toHaveLength(1)
-      expect(wrapper.emitted('input')).toBeUndefined()
+      expect(wrapper.emitted('input')).toHaveLength(1)
     })
 
     it('as an option of a select as selected', async () => {
@@ -68,11 +73,7 @@ describe('setValue', () => {
 
       const Component = {
         setup() {
-          return () =>
-            h('select', { onChange: handle }, [
-              h('option', { value: 'A' }),
-              h('option', { value: 'B' })
-            ])
+          return () => h('select', { onChange: handle }, renderOptions())
         }
       }
 
@@ -98,7 +99,7 @@ describe('setValue', () => {
       expect(wrapper.vm.multiselectVal).toEqual(['selectA', 'selectC'])
 
       expect(wrapper.emitted('change')).toHaveLength(1)
-      expect(wrapper.emitted('input')).toBeUndefined()
+      expect(wrapper.emitted('input')).toHaveLength(1)
     })
 
     it('overrides elements of multiselect', async () => {
@@ -114,7 +115,37 @@ describe('setValue', () => {
       expect(wrapper.vm.multiselectVal).toEqual(['selectB'])
 
       expect(wrapper.emitted('change')).toHaveLength(2)
-      expect(wrapper.emitted('input')).toBeUndefined()
+      expect(wrapper.emitted('input')).toHaveLength(2)
+    })
+
+    it('does trigger input and change event on select', async () => {
+      const onInput = vi.fn()
+      const onChange = vi.fn()
+      const Comp = defineComponent({
+        setup() {
+          return () => h('select', { onInput, onChange }, renderOptions())
+        }
+      })
+
+      await mount(Comp).find('select').setValue('A')
+
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('does trigger input and change event on option select', async () => {
+      const onInput = vi.fn()
+      const onChange = vi.fn()
+      const Comp = defineComponent({
+        setup() {
+          return () => h('select', { onInput, onChange }, renderOptions())
+        }
+      })
+
+      await mount(Comp).findAll('option')[1].setValue()
+
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -201,6 +232,46 @@ describe('setValue', () => {
 
       const fn = radioFoo.setValue(false)
       await expect(fn).rejects.toThrowError(message)
+    })
+
+    it('does trigger input and change event on checkbox', async () => {
+      const onInput = vi.fn()
+      const onChange = vi.fn()
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h('input', {
+              onInput,
+              onChange,
+              type: 'checkbox'
+            })
+        }
+      })
+
+      await mount(Comp).find('input').setValue()
+
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('does trigger input and change event on radio', async () => {
+      const onInput = vi.fn()
+      const onChange = vi.fn()
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h('input', {
+              onInput,
+              onChange,
+              type: 'radio'
+            })
+        }
+      })
+
+      await mount(Comp).find('input').setValue()
+
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
Adds missing trigger of `input` event when calling `setValue` on the following elements:
- `input[type=checkbox]`
- `input[type=radio]`
- `select`
- `option`

fix #2014 

I've created a playground to test the event trigger of the browser, to match the same behavior:
https://sfc.vuejs.org/#eNrNVM1u2zAMfhVClyRAY6M5Bk6wYdgLbMdpB1dhYrW2JEiy28Dwu5eSnDRN/wIUBeqLSX4f+ZG2qJ79NCbrWmRLVjhhpfHg0LdmzZVsjLYeerBYCi87hAG2VjcwIf6EK66EVs5DrXewOpKm//7PDohUpvVA4HQGqzVVImpmWldNJwkSZV3jZjKD4ZAiqlLt8PWcETtNKvLUNLVLjsfG1KVH8gCKjezWAMEkp1rEYHh+VSjubvTDiOQjxH2RmvJ7gyvOxIHG4EcEKBbfIZBaiaxgcJYk86AZWhnlX4r/KTdSf6BsI+ciWVBlc5LyFeUuGOov1ij82VRkuhi/+PPFHG281Aq6sm4D4Zqw6yJP0TdZC2Itzlh0NKL8syHSeXh3DGja2ktT42fmORb5FoP97lDFPT0/eMk9rA108622pDolut1fgZzRCsc8Bss73IeRT//Vk1p4+h5iHgy0mCPj2F2wn6/nCJ2E2RVLd868KU1267SiW6mPjY6A42wJMRJidA0Fn7PKe+OWee62Itxlty7TdpeTldlWedlghq6Z31h979BSYc5CCepyYMMj1fSWsw==


