### PR TITLE
fix: allow finding async component stubs by definition

### DIFF
--- a/tests/features/async-components.spec.ts
+++ b/tests/features/async-components.spec.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { defineAsyncComponent, defineComponent, h, AppConfig } from 'vue'
-import { mount, flushPromises } from '../../src'
+import { mount, shallowMount, flushPromises } from '../../src'
+import Hello from '../components/Hello.vue'
 
 const config: Partial<AppConfig> = {
   errorHandler: (error: unknown) => {
@@ -107,5 +108,39 @@ describe('defineAsyncComponent', () => {
     await flushPromises()
     await vi.dynamicImportSettled()
     expect(wrapper.html()).toContain('Hello world')
+  })
+
+  it('finds Async Component by async definition when using shallow mount', async () => {
+    const AsyncHello = defineAsyncComponent(
+      () => import('../components/Hello.vue')
+    )
+
+    const Comp = defineComponent({
+      render() {
+        return h(AsyncHello)
+      }
+    })
+
+    const wrapper = shallowMount(Comp)
+    await flushPromises()
+    await vi.dynamicImportSettled()
+    expect(wrapper.findComponent(AsyncHello).exists()).toBe(true)
+  })
+
+  it('finds Async Component by definition when using shallow mount', async () => {
+    const AsyncHello = defineAsyncComponent(
+      () => import('../components/Hello.vue')
+    )
+
+    const Comp = defineComponent({
+      render() {
+        return h(AsyncHello)
+      }
+    })
+
+    const wrapper = shallowMount(Comp)
+    await flushPromises()
+    await vi.dynamicImportSettled()
+    expect(wrapper.findComponent(Hello).exists()).toBe(true)
   })
 })

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -8,7 +8,6 @@ import {
   vi
 } from 'vitest'
 import { ComponentPublicInstance, h } from 'vue'
-
 import { mount, config, VueWrapper } from '../../src'
 
 declare module '../../src/vueWrapper' {
@@ -145,11 +144,13 @@ describe('createStubs', () => {
     expect(customCreateStub).toHaveBeenCalledTimes(2)
     expect(customCreateStub).toHaveBeenCalledWith({
       name: 'child1',
-      component: Child1
+      component: Child1,
+      registerStub: expect.any(Function)
     })
     expect(customCreateStub).toHaveBeenCalledWith({
       name: 'child2',
-      component: Child2
+      component: Child2,
+      registerStub: expect.any(Function)
     })
   })
 
@@ -173,7 +174,8 @@ describe('createStubs', () => {
     expect(customCreateStub).toHaveBeenCalledTimes(1)
     expect(customCreateStub).toHaveBeenCalledWith({
       name: 'child2',
-      component: Child2
+      component: Child2,
+      registerStub: expect.any(Function)
     })
   })
 
@@ -212,7 +214,8 @@ describe('createStubs', () => {
     expect(customCreateStub).toHaveBeenCalledTimes(1)
     expect(customCreateStub).toHaveBeenCalledWith({
       name: 'child1',
-      component: Child1
+      component: Child1,
+      registerStub: expect.any(Function)
     })
   })
 })

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -679,16 +679,16 @@ describe('mounting options: stubs', () => {
   })
 
   describe('stub async component', () => {
-    const AsyncComponent = defineAsyncComponent(async () => ({
-      name: 'AsyncComponent',
-      template: '<span>AsyncComponent</span>'
-    }))
-
     const AsyncComponentWithoutName = defineAsyncComponent(async () => ({
       template: '<span>AsyncComponent</span>'
     }))
 
     it('stubs async component with name', async () => {
+      const AsyncComponent = defineAsyncComponent(async () => ({
+        name: 'AsyncComponent',
+        template: '<span>AsyncComponent</span>'
+      }))
+
       const TestComponent = defineComponent({
         components: {
           MyComponent: AsyncComponent
@@ -716,6 +716,11 @@ describe('mounting options: stubs', () => {
     })
 
     it('stubs async component with name by alias', () => {
+      const AsyncComponent = defineAsyncComponent(async () => ({
+        name: 'AsyncComponent',
+        template: '<span>AsyncComponent</span>'
+      }))
+
       const TestComponent = defineComponent({
         components: {
           MyComponent: AsyncComponent


### PR DESCRIPTION
This MR introduces an ability to find async component stubs by definition of **underlying** component, not just by wrapper itself

It also mimics `@vue/test-utils@1.x` behavior (well, kinda) - `@vue/test-utils@1.x` was unable to stub async components due to limitations in our patch approach, so "finding" always worked cause there were no stubs

