### PR TITLE
chore: use a stackblitz repro with create-vue for issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ assignees: ''
 
 **To Reproduce**
 <!-- A link to a minimal reproduction (with the minimum code to reproduce the issue). 
-It takes just a few minutes to build a repro online with https://stackblitz.com/fork/github/vitest-dev/vitest/tree/main/examples/vue?initialPath=__vitest__
+It takes just a few minutes to build a repro online with https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/typescript-vitest?file=src%2Fcomponents%2F__tests__%2FHelloWorld.spec.ts
 -->
 
 **Expected behavior**


### PR DESCRIPTION
As we do receive quite a few issues about types, I think it would be nice to use repros that come with vue-tsc (and vitest of course) out of the box.

Note that this link can point to any of the snapshots listed here https://github.com/vuejs/create-vue-templates/tree/main but I suppose a minimal one by default is better