### PR TITLE
fix(stub): rename prefix prop to avoid warning on render

### DIFF
--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -37,17 +37,28 @@ interface StubOptions {
   renderStubDefaultSlot?: boolean
 }
 
+const mapStubPropValue = (value: unknown) => {
+  if (typeof value === 'symbol') {
+    return value?.toString()
+  } else if (typeof value === 'function') {
+    return '[Function]'
+  }
+
+  return value
+}
 const normalizeStubProps = (props: ComponentPropsOptions) => {
   // props are always normalized to object syntax
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
-    if (typeof $props[key] === 'symbol') {
-      return { ...acc, [key]: $props[key]?.toString() }
+    let propName = key
+
+    // Rename `prefix` prop because it's shared with Element prop and will output a warning on render
+    // https://developer.mozilla.org/en-US/docs/Web/API/Element/prefix
+    if (propName === 'prefix') {
+      propName = '_prefix'
     }
-    if (typeof $props[key] === 'function') {
-      return { ...acc, [key]: '[Function]' }
-    }
-    return { ...acc, [key]: $props[key] }
+
+    return { ...acc, [propName]: mapStubPropValue($props[key]) }
   }, {})
 }
 

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -246,7 +246,7 @@ describe('shallowMount', () => {
       { shallow: true }
     )
     expect(wrapper.html()).toBe(
-      '<test-comp-stub prefix="foo"></test-comp-stub>'
+      '<test-comp-stub _prefix="foo"></test-comp-stub>'
     )
 
     expect(wrapper.findComponent(TestComp).props('prefix')).toBe('foo')

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineAsyncComponent, defineComponent } from 'vue'
 import { mount, shallowMount, VueWrapper } from '../src'
 import ComponentWithChildren from './components/ComponentWithChildren.vue'
@@ -225,5 +225,33 @@ describe('shallowMount', () => {
     const wrapper = shallowMount(DynamicComponentWithComputedProperty)
 
     expect(wrapper.find('computed-property-stub').exists()).toBe(false)
+  })
+
+  it('should set prop that is shared with Element', async () => {
+    const spyWarn = vi.spyOn(console, 'warn')
+
+    const TestComp = defineComponent({
+      props: {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Element/prefix
+        prefix: String
+      },
+      template: '<div />'
+    })
+
+    const wrapper = mount(
+      defineComponent({
+        components: { TestComp },
+        template: '<TestComp prefix="foo" />'
+      }),
+      { shallow: true }
+    )
+    expect(wrapper.html()).toBe(
+      '<test-comp-stub prefix="foo"></test-comp-stub>'
+    )
+
+    expect(wrapper.findComponent(TestComp).props('prefix')).toBe('foo')
+
+    expect(spyWarn).not.toHaveBeenCalled()
+    spyWarn.mockRestore()
   })
 })


### PR DESCRIPTION
My only solution currently would be to rename the `prefix` property on render to `_prefix` for example. Not nice but this would only affect the `.html()` output `.props('prefix')` would still work.

In case we decide to use this solution, then I would add something to the docs

Fix #2035 