### PR TITLE
docs: add FAQ for "Vue warn: Failed setting prop"

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -107,6 +107,10 @@ export default defineConfig({
             ]
           },
           {
+            text: 'FAQ',
+            link: '/guide/faq/'
+          },
+          {
             text: 'Migrating from Vue 2',
             link: '/migration/'
           },
@@ -213,6 +217,10 @@ export default defineConfig({
             link: '/guide/extending-vtu/community-learning'
           }
         ]
+      },
+      {
+        text: 'FAQ',
+        link: '/guide/faq/'
       },
       {
         text: 'Migrating from Vue 2',

--- a/docs/guide/faq/index.md
+++ b/docs/guide/faq/index.md
@@ -1,0 +1,25 @@
+# FAQ
+
+[[toc]]
+
+## Vue warn: Failed setting prop
+
+```
+[Vue warn]: Failed setting prop "prefix" on <component-stub>: value foo is invalid.
+TypeError: Cannot set property prefix of #<Element> which has only a getter
+```
+
+This warning is shown in case you are using `shallowMount` or `stubs` with a property name that is shared with [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element).
+
+Common property names that are shared with `Element`:
+* `attributes`
+* `children`
+* `prefix`
+
+See: https://developer.mozilla.org/en-US/docs/Web/API/Element
+
+**Possible solutions**
+
+1. Use `mount` instead of `shallowMount` to render without stubs
+2. Ignore the warning by mocking `console.warn`
+3. Rename the prop to not clash with `Element` properties


### PR DESCRIPTION
Added a FAQ section to the docs and some info about the `Vue warn: Failed setting prop`

Relates:
#2035
#1995

Makes obsolete: #2067

