### PR TITLE
chore: show links on create of github issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/vuejs/test-utils/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.
+  - name: Vue.js 2 / test-utils v1
+    url: https://github.com/vuejs/vue-test-utils
+    about: @vue/test-utils v1 for Vue.js 2 is in a separate repository


### PR DESCRIPTION
Adds two links when creating a issue. One to discussions and another to the test-utils v1 repo
Example on vitest repo: https://github.com/vitest-dev/vitest/issues/new/choose