### PR TITLE
chore: update pnpm version on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v2.2.4
       with:
-        version: 7.5.0
+        version: 8.6.3
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
The generated lockfile was no longer compatible, so pnpm was not using it on CI.