### PR TITLE
chore: specify pnpm v8 as package manager

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
 [[redirects]]
   from="/v2"
   to="/"
+
+[build]
+  command = "pnpm docs:build"

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "url": "git+https://github.com/vuejs/test-utils.git"
   },
   "homepage": "https://github.com/vuejs/test-utils",
+  "packageManager": "pnpm@8.6.3",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [


### PR DESCRIPTION
This is especially useful for netlify which rely on corepack to use the proper pnpm version. Corepack uses the `packageManager` field in the pakage.json file to determine which version is used.