### PR TITLE
chore: compiler-dom as required dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,14 +65,10 @@
     "vuex": "4.1.0"
   },
   "peerDependencies": {
-    "@vue/compiler-dom": "^3.0.1",
     "@vue/server-renderer": "^3.0.1",
     "vue": "^3.0.1"
   },
   "peerDependenciesMeta": {
-    "@vue/compiler-dom": {
-      "optional": true
-    },
     "@vue/server-renderer": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
The `processSlot` function needs `compiler-dom` so the dependency should not be marked as optional. Fixes #2107