### PR TITLE
feat: include the mocks in component globalThis

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -505,6 +505,15 @@ export default {
   }
 }
 </script>
+
+// Or if you are using script setup
+
+<script setup>
+function onClick() {
+  $store.dispatch('click')
+}
+</script>
+
 ```
 
 `Component.spec.js`:

--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -228,6 +228,8 @@ export function createInstance(
               this.$.setupState[k] = v
               // eslint-disable-next-line no-empty
             } catch (e) {}
+            //@ts-ignore Setting an unknown global variable for the component instance
+            globalThis[k] = v
           }
           // also intercept the proxy calls to make the mocks available on the instance
           // (useful when a template access a global function like $t and the developer wants to mock it)

--- a/tests/components/ScriptSetupWithGlobalFunction.vue
+++ b/tests/components/ScriptSetupWithGlobalFunction.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+const hello = ref('hello')
+
+function clicked() {
+  //@ts-ignore For example Nuxt will inject these kinds of global functions
+  $fetch('http://www.example.com').then((response : any) => {
+    hello.value = response.data
+  })
+}
+
+</script>
+
+<template>
+  <button @click="clicked">{{ hello }}</button>
+</template>

--- a/tests/mountingOptions/mocks.spec.ts
+++ b/tests/mountingOptions/mocks.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { mount, RouterLinkStub } from '../../src'
 import { defineComponent } from 'vue'
 import ScriptSetupWithI18n from '../components/ScriptSetupWithI18n.vue'
+import ScriptSetupWithGlobalFunction from '../components/ScriptSetupWithGlobalFunction.vue'
 import ComponentWithI18n from '../components/ComponentWithI18n.vue'
 
 describe('mocks', () => {
@@ -87,6 +88,19 @@ describe('mocks', () => {
       }
     })
     expect(wrapper.text()).toContain('hello')
+    expect(wrapper.text()).toContain('mocked')
+  })
+
+  it('mocks a global function used in a script setup', async () => {
+    const wrapper = mount(ScriptSetupWithGlobalFunction, {
+      global: {
+        mocks: {
+          $fetch: async (url) => ({ data: 'mocked' })
+        }
+      }
+    })
+    expect(wrapper.text()).toContain('hello')
+    await wrapper.find('button').trigger('click')
     expect(wrapper.text()).toContain('mocked')
   })
 

--- a/tests/mountingOptions/mocks.spec.ts
+++ b/tests/mountingOptions/mocks.spec.ts
@@ -95,7 +95,7 @@ describe('mocks', () => {
     const wrapper = mount(ScriptSetupWithGlobalFunction, {
       global: {
         mocks: {
-          $fetch: async (url) => ({ data: 'mocked' })
+          $fetch: async (url: string) => ({ data: 'mocked' })
         }
       }
     })


### PR DESCRIPTION
In the components beforeCreate we include all the mocks also in `globalThis`. That way the mocks are usable also in the `script setup` part of the component.

This PR contains the unit test and the solution.

Fixes #2119