### PR TITLE
docs: add warning about `isVisible()`

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1433,6 +1433,10 @@ isVisible(): boolean
 
 **Details:**
 
+::: warning
+`isVisible()` only works correctly if the wrapper is attached to the DOM using [`attachTo`](#attachto)
+:::
+
 ```js
 const Component = {
   template: `<div v-show="false"><span /></div>`


### PR DESCRIPTION
This change updates the documentation to reflect that `isVisible()` will only work correctly [when attached to the DOM][1] because of an upstream [`jsdom` issue][2].

[1]: https://github.com/vuejs/test-utils/issues/2016
[2]: https://github.com/jsdom/jsdom/issues/3502