### PR TITLE
chore: exception for no-extra-semi lint rule

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,7 @@ class Pluggable<Instance = DOMWrapper<Node>> {
       return handler(instance, options) // invoke the setup method passed to install
     }
     const bindProperty = ([property, value]: [string, any]) => {
+      // eslint-disable-next-line no-extra-semi
       ;(instance as any)[property] =
         typeof value === 'function' ? value.bind(instance) : value
     }

--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -231,6 +231,7 @@ export function createInstance(
           }
           // also intercept the proxy calls to make the mocks available on the instance
           // (useful when a template access a global function like $t and the developer wants to mock it)
+          // eslint-disable-next-line no-extra-semi
           ;(this.$ as any).proxy = new Proxy((this.$ as any).proxy, {
             get(target, key) {
               if (key in global.mocks) {
@@ -243,6 +244,7 @@ export function createInstance(
           for (const [k, v] of Object.entries(
             global.mocks as { [key: string]: any }
           )) {
+            // eslint-disable-next-line no-extra-semi
             ;(this as any)[k] = v
           }
         }


### PR DESCRIPTION
typescript-eslint v6 don't want them, but prettier adds them.