### PR TITLE
chore: use server.deps.inline for vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,8 +26,10 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: [path.resolve(__dirname, './setup.js')],
     include: ['tests/**/*.spec.ts'],
-    deps: {
-      inline: ['vue', '@vue/compat']
+    server: {
+      deps: {
+        inline: ['vue', '@vue/compat']
+      }
     },
     sequence: {
       shuffle: true


### PR DESCRIPTION
This gets rid of the warning we currently have when running `pnpm test`:

```
Vitest  "deps.inline" is deprecated. If you rely on vite-node directly, use "server.deps.inline" instead. Otherwise, consider using "deps.optimizer.web.include"
```