### PR TITLE
Fixing prototype methods being discarded when using `setData`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,20 +80,22 @@ export const mergeDeep = (
   if (!isObject(target) || !isObject(source)) {
     return source
   }
-  Object.keys(source).forEach((key) => {
-    const targetValue = target[key]
-    const sourceValue = source[key]
+  Object.keys(source)
+    .concat(Object.getOwnPropertyNames(Object.getPrototypeOf(source) ?? {}))
+    .forEach((key) => {
+      const targetValue = target[key]
+      const sourceValue = source[key]
 
-    if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
-      target[key] = sourceValue
-    } else if (sourceValue instanceof Date) {
-      target[key] = sourceValue
-    } else if (isObject(targetValue) && isObject(sourceValue)) {
-      target[key] = mergeDeep(Object.assign({}, targetValue), sourceValue)
-    } else {
-      target[key] = sourceValue
-    }
-  })
+      if (Array.isArray(targetValue) && Array.isArray(sourceValue)) {
+        target[key] = sourceValue
+      } else if (sourceValue instanceof Date) {
+        target[key] = sourceValue
+      } else if (isObject(targetValue) && isObject(sourceValue)) {
+        target[key] = mergeDeep(Object.assign({}, targetValue), sourceValue)
+      } else {
+        target[key] = sourceValue
+      }
+    })
 
   return target
 }

--- a/tests/setData.spec.ts
+++ b/tests/setData.spec.ts
@@ -218,7 +218,8 @@ describe('setData', () => {
   it('should retain prototype methods for constructed objects when calling setData', async () => {
     const expectedResult = 'success!'
     class TestClass {
-      getResult() {
+      constructor(readonly name: string) {}
+      getResult(): string {
         return expectedResult
       }
     }
@@ -227,22 +228,22 @@ describe('setData', () => {
       defineComponent({
         template: '<div/>',
         data() {
-          return { value: new TestClass() }
+          return { value: new TestClass('test1') }
         },
         methods: {
           getResult() {
-            return this.value.getResult()
+            return `${this.value.name}: ${this.value.getResult()}`
           }
         }
       })
     )
 
-    expect(wrapper.vm.getResult()).toStrictEqual(expectedResult)
+    expect(wrapper.vm.getResult()).toStrictEqual(`test1: ${expectedResult}`)
 
     await wrapper.setData({
-      value: new TestClass()
+      value: new TestClass('test2')
     })
 
-    expect(wrapper.vm.getResult()).toStrictEqual(expectedResult)
+    expect(wrapper.vm.getResult()).toStrictEqual(`test2: ${expectedResult}`)
   })
 })

--- a/tests/setData.spec.ts
+++ b/tests/setData.spec.ts
@@ -214,4 +214,35 @@ describe('setData', () => {
     expect(wrapper.vm.value).toBeInstanceOf(Date)
     expect(wrapper.vm.value!.toISOString()).toBe('2022-08-11T12:15:54.000Z')
   })
+
+  it('should retain prototype methods for constructed objects when calling setData', async () => {
+    const expectedResult = 'success!'
+    class TestClass {
+      getResult() {
+        return expectedResult
+      }
+    }
+
+    const wrapper = mount(
+      defineComponent({
+        template: '<div/>',
+        data() {
+          return { value: new TestClass() }
+        },
+        methods: {
+          getResult() {
+            return this.value.getResult()
+          }
+        }
+      })
+    )
+
+    expect(wrapper.vm.getResult()).toStrictEqual(expectedResult)
+
+    await wrapper.setData({
+      value: new TestClass()
+    })
+
+    expect(wrapper.vm.getResult()).toStrictEqual(expectedResult)
+  })
 })


### PR DESCRIPTION
Currently when calling `setData` on a wrapper it will not retain methods on any constructed objects passed in. These methods reside in the prototype which the current logic do not persist across. These changes will ensure that any prototype properties / methods are copied over to the proxied data object.

fixes https://github.com/vuejs/test-utils/issues/1851