### PR TITLE
docs: comparison of functions with v1

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -309,7 +309,7 @@ This is table for those coming from VTU 1, comparing the two APIs.
 | attachToDocument | renamed `attachTo`. See [here](https://github.com/vuejs/vue-test-utils/pull/1492) |
 | scopedSlots      | removed. ScopedSlots are merged with `slots` in Vue 3                             |
 | context          | removed. Different from Vue 2, does not make sense anymore.                       |
-| localVue         | removed. No longer required - Vue 3 there is no global Vue instance to mutate.    |
+| localVue         | removed. No longer required - in Vue 3 there is no global Vue instance to mutate. |
 | listeners        | removed. No longer exists in Vue 3                                                |
 | parentComponent  | removed                                                                           |
 
@@ -317,7 +317,7 @@ This is table for those coming from VTU 1, comparing the two APIs.
 
 | method         | notes                                                                                       |
 |----------------|---------------------------------------------------------------------------------------------|
-| find           | only `querySelector` syntax is supported. Use `findComponent(Comp)`                         |
+| find           | only `querySelector` syntax is supported. Use `findComponent(Comp)` to find a Vue component |
 | setValue       | works for select, checkbox, radio button, input, textarea. Returns `nextTick`.              |
 | trigger        | returns `nextTick`. You can do `await wrapper.find('button').trigger('click')`              |
 | destroy        | renamed to `unmount` to match Vue 3 lifecycle hook name.                                    |
@@ -326,7 +326,7 @@ This is table for those coming from VTU 1, comparing the two APIs.
 | setSelected    | removed. Now part of `setValue`                                                             |
 | setChecked     | removed. Now part of `setValue`                                                             |
 | is             | removed                                                                                     |
-| isEmpty        | removed. use matchers such as [this](https://github.com/testing-library/jest-dom#tobeempty) |
+| isEmpty        | removed. Use matchers such as [this](https://github.com/testing-library/jest-dom#tobeempty) |
 | isVueInstance  | removed                                                                                     |
 | name           | removed                                                                                     |
 | setMethods     | removed                                                                                     |

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -290,3 +290,43 @@ If you use snapshot testing and comment nodes are leaking into your snapshots, n
   }
   ```
 - Via `@vue/test-utils` [`mountingOptions.global.config`](https://test-utils.vuejs.org/api/#global) either globally or on per-test basis.
+
+## Comparison with v1
+
+This is table for those coming from VTU 1, comparing the two APIs.
+
+### Mounting Options
+
+| option           | notes                                                                             |
+|------------------|-----------------------------------------------------------------------------------|
+| mocks            | nested in `global`                                                                |
+| propsData        | now called `props`                                                                |
+| provide          | nested in `global`                                                                |
+| mixins           | nested in `global`                                                                |
+| plugins          | nested in `global`                                                                |
+| component        | nested in `global`                                                                |
+| directives       | nested in `global`                                                                |
+| attachToDocument | renamed `attachTo`. See [here](https://github.com/vuejs/vue-test-utils/pull/1492) |
+| scopedSlots      | removed. ScopedSlots are merged with `slots` in Vue 3                             |
+| context          | removed. Different from Vue 2, does not make sense anymore.                       |
+| localVue         | removed. No longer required - Vue 3 there is no global Vue instance to mutate.    |
+| listeners        | removed. No longer exists in Vue 3                                                |
+| parentComponent  | removed                                                                           |
+
+### Wrapper API (mount)
+
+| method         | notes                                                                                       |
+|----------------|---------------------------------------------------------------------------------------------|
+| find           | only `querySelector` syntax is supported. Use `findComponent(Comp)`                         |
+| setValue       | works for select, checkbox, radio button, input, textarea. Returns `nextTick`.              |
+| trigger        | returns `nextTick`. You can do `await wrapper.find('button').trigger('click')`              |
+| destroy        | renamed to `unmount` to match Vue 3 lifecycle hook name.                                    |
+| contains       | removed. Use `find`                                                                         |
+| emittedByOrder | removed. Use `emitted`                                                                      |
+| setSelected    | removed. Now part of `setValue`                                                             |
+| setChecked     | removed. Now part of `setValue`                                                             |
+| is             | removed                                                                                     |
+| isEmpty        | removed. use matchers such as [this](https://github.com/testing-library/jest-dom#tobeempty) |
+| isVueInstance  | removed                                                                                     |
+| name           | removed                                                                                     |
+| setMethods     | removed                                                                                     |


### PR DESCRIPTION
Adds a comparison table of functions with v1. It has been taken from the previous table of the README.md https://github.com/vuejs/test-utils/commit/11b34745e8e66fc747881dfb1ce94cef537c455e

Preview: https://deploy-preview-2175--vue-test-utils-docs.netlify.app/migration/#Comparison-with-v1 

close #2147 