### PR TITLE
Fix: calling element method instead of trigger DOM event

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -376,7 +376,8 @@ export default abstract class BaseWrapper<ElementType extends Node>
       if (typeof element[eventString] === 'function') {
         element.addEventListener(
           eventString,
-          (event) => {
+          (nativeEvent) => {
+            const event = nativeEvent as Event & { _vts: number }
             // see https://github.com/vuejs/test-utils/issues/1854
             // fakeTimers provoke an issue as Date.now() always return the same value
             // and Vue relies on it to determine if the handler should be invoked

--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -370,15 +370,21 @@ export default abstract class BaseWrapper<ElementType extends Node>
     }
 
     if (this.element && !this.isDisabled()) {
-      const event = createDOMEvent(eventString, options)
-      // see https://github.com/vuejs/test-utils/issues/1854
-      // fakeTimers provoke an issue as Date.now() always return the same value
-      // and Vue relies on it to determine if the handler should be invoked
-      // see https://github.com/vuejs/core/blob/5ee40532a63e0b792e0c1eccf3cf68546a4e23e9/packages/runtime-dom/src/modules/events.ts#L100-L104
-      // we workaround this issue by manually setting _vts to Date.now() + 1
-      // thus making sure the event handler is invoked
-      event._vts = Date.now() + 1
-      this.element.dispatchEvent(event)
+      const element = this.element as unknown as Record<string, Function>
+      if (typeof element[eventString] === 'function') {
+        // Try to call `element.click()`, `element.focus()`, ... in favor of DOM event
+        element[eventString]()
+      } else {
+        const event = createDOMEvent(eventString, options)
+        // see https://github.com/vuejs/test-utils/issues/1854
+        // fakeTimers provoke an issue as Date.now() always return the same value
+        // and Vue relies on it to determine if the handler should be invoked
+        // see https://github.com/vuejs/core/blob/5ee40532a63e0b792e0c1eccf3cf68546a4e23e9/packages/runtime-dom/src/modules/events.ts#L100-L104
+        // we workaround this issue by manually setting _vts to Date.now() + 1
+        // thus making sure the event handler is invoked
+        event._vts = Date.now() + 1
+        this.element.dispatchEvent(event)
+      }
     }
 
     return nextTick()

--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, ref } from 'vue'
 
-import { mount } from '../src'
+import { flushPromises, mount } from '../src'
 import { keyCodesByKeyName, KeyName } from '../src/createDomEvent'
 
 describe('trigger', () => {
@@ -25,6 +25,30 @@ describe('trigger', () => {
 
       const wrapper = mount(Component)
       await wrapper.trigger('click')
+
+      expect(wrapper.text()).toBe('Count: 1')
+    })
+
+    it('work with click event on element', async () => {
+      const Component = defineComponent({
+        setup() {
+          return {
+            count: ref(0)
+          }
+        },
+
+        render() {
+          return h(
+            'div',
+            { onClick: () => this.count++ },
+            `Count: ${this.count}`
+          )
+        }
+      })
+
+      const wrapper = mount(Component)
+      wrapper.find('div').element.click()
+      await flushPromises()
 
       expect(wrapper.text()).toBe('Count: 1')
     })
@@ -113,6 +137,35 @@ describe('trigger', () => {
       expect(wrapper.classes()).not.toContain('active')
       await wrapper.trigger('click')
       expect(wrapper.classes()).toContain('active')
+    })
+  })
+
+  describe('on focus', () => {
+    it('focus element', async () => {
+      const Component = defineComponent({
+        setup() {
+          return {
+            count: ref(0)
+          }
+        },
+
+        render() {
+          return h(
+            'button',
+            { onFocus: () => this.count++ },
+            `Count: ${this.count}`
+          )
+        }
+      })
+
+      const wrapper = mount(Component, {
+        attachTo: document.body
+      })
+      const button = wrapper.find('button')
+      await button.trigger('focus')
+
+      expect(button.text()).toBe('Count: 1')
+      expect(document.activeElement).toBe(button.element)
     })
   })
 


### PR DESCRIPTION
Calls `element.click()`, `element.focus()`, etc. on `trigger('click')` instead of dispatching a DOM event.

I was able to get it working, but I'm not really convinced of the implementation.

Fix #2176 


