### PR TITLE
ci: add node v20 and drop node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [16, 18]
+        node: [18, 20]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
node v16 is now EOL, and v20 is the active one.
See https://github.com/nodejs/release#release-schedule