### PR TITLE
fix: don't require optional peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,14 @@
     "vuex": "4.1.0"
   },
   "peerDependencies": {
+    "@vue/compiler-dom": "^3.0.1",
     "@vue/server-renderer": "^3.0.1",
     "vue": "^3.0.1"
   },
   "peerDependenciesMeta": {
+    "@vue/compiler-dom": {
+      "optional": true
+    },
     "@vue/server-renderer": {
       "optional": true
     }

--- a/src/renderToString.ts
+++ b/src/renderToString.ts
@@ -1,8 +1,8 @@
-import { renderToString as baseRenderToString } from '@vue/server-renderer'
 import { DefineComponent } from 'vue'
 import { createInstance } from './createInstance'
 import { ComponentMountingOptions } from './mount'
 import { RenderMountingOptions } from './types'
+import { requireVueServerRenderer } from './utils/requireOptionalPeer'
 
 export function renderToString<
   T,
@@ -22,6 +22,8 @@ export function renderToString<
 ): Promise<string>
 
 export function renderToString(component: any, options?: any): Promise<string> {
+  const { renderToString: baseRenderToString } = requireVueServerRenderer()
+
   if (options?.attachTo) {
     console.warn('attachTo option is not available for renderToString')
   }

--- a/src/utils/compileSlots.ts
+++ b/src/utils/compileSlots.ts
@@ -1,7 +1,9 @@
-import { compile } from '@vue/compiler-dom'
 import * as vue from 'vue'
+import { requireVueCompilerDom } from './requireOptionalPeer'
 
 export function processSlot(source = '', Vue = vue) {
+  const { compile } = requireVueCompilerDom()
+
   let template = source.trim()
   const hasWrappingTemplate = template && template.startsWith('<template')
 

--- a/src/utils/requireOptionalPeer.ts
+++ b/src/utils/requireOptionalPeer.ts
@@ -1,0 +1,27 @@
+import { createRequire } from 'module'
+
+// @ts-ignore - cjs build will complain about import.meta not being allowed, but its not actually used as __filename will be defined for cjs
+const file = typeof __filename !== 'undefined' ? __filename : import.meta.url
+const require = createRequire(file)
+
+export function requireOptional(packageName: string): unknown {
+  try {
+    return require(packageName)
+  } catch {
+    throw new Error(
+      `The optional peer-dependency ${packageName} is needed for this test and was not found. Please ensure that it has been installed as a dev-dependency and retry.`
+    )
+  }
+}
+
+export function requireVueCompilerDom() {
+  return requireOptional(
+    '@vue/compiler-dom'
+  ) as typeof import('@vue/compiler-dom')
+}
+
+export function requireVueServerRenderer() {
+  return requireOptional(
+    '@vue/server-renderer'
+  ) as typeof import('@vue/server-renderer')
+}


### PR DESCRIPTION
`@vue/server-renderer` and `@vue/compiler-dom` were both required in the
sense that they will throw regardless of whether or not your are using
functionality from those libraries if they weren't installed. I don't
believe this was intentional, so I have made them optional and they will
now only throw if you try to use them and the package isn't available,
and will print a more helpful error message when doing so.