### PR TITLE
fix: wrapper.text method

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -261,7 +261,7 @@ export default abstract class BaseWrapper<ElementType extends Node>
   }
 
   text() {
-    return textContent(this.element)
+    return this.getRootNodes().map(textContent).join('')
   }
 
   exists() {

--- a/tests/text.spec.ts
+++ b/tests/text.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, Suspense } from 'vue'
 
 import { mount } from '../src'
 
@@ -92,5 +92,25 @@ describe('text', () => {
   it('returns correct text for root slot with nested component', () => {
     const wrapper = mount(() => h(ReturnSlot, {}, () => h(MultiRootText)))
     expect(wrapper.text()).toBe('foobarbaz')
+  })
+
+  it('returns correct text for suspense component has multiple elements in a slot', () => {
+    const wrapper = mount({
+      render: () =>
+        h(
+          Suspense,
+          {},
+          {
+            default: () =>
+              h(
+                defineComponent({
+                  template: `<!-- some comments --><div>Text content</div>`
+                })
+              )
+          }
+        )
+    })
+
+    expect(wrapper.text()).toBe('Text content')
   })
 })


### PR DESCRIPTION
### Summary

This change fixes wrapper.text to handle suspense components with multiple elements in a slot.
When suspense component had multiple elements in a slot, wrapper.text returned empty.