### PR TITLE
chore: use experimentalVmThreads to run unit tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    experimentalVmThreads: true,
     setupFiles: [path.resolve(__dirname, './setup.js')],
     include: ['tests/**/*.spec.ts'],
     server: {


### PR DESCRIPTION
Tests are roughly twice faster with this option.

Before:
```
Duration  7.58s (transform 859ms, setup 441ms, collect 8.55s, tests 2.61s, environment 15.28s, prepare 3.19s)
```

After:
```
Duration  3.06s (transform 1.03s, setup 344ms, collect 7.36s, tests 2.08s, environment 1.58s, prepare 4.25s)
```