### PR TITLE
fix(types): use `VNodeChild` type from `vue` to avoid breakage

### DIFF
--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,6 +1,7 @@
 import {
   ComponentInternalInstance,
   VNode,
+  VNodeChild,
   VNodeArrayChildren,
   VNodeNormalizedChildren,
   VNodeTypes
@@ -92,16 +93,8 @@ export function matches(
  * to only keep VNode and VNodeArrayChildren values
  * @param value
  */
-function nodesAsObject<Node>(
-  value:
-    | string
-    | number
-    | boolean
-    | VNodeArrayChildren
-    | VNode
-    | null
-    | undefined
-    | void
+function nodesAsObject(
+  value: VNodeChild | VNodeArrayChildren
 ): value is VNodeArrayChildren | VNode {
   return !!value && typeof value === 'object'
 }


### PR DESCRIPTION
This fixes the test failure in https://github.com/vuejs/test-utils/pull/2233

Vue 3.3.8 added a new type in the `VNodeChildAtom` union type: https://github.com/vuejs/core/commit/405f34587a63a5f1e3d147b9848219ea98acc22d#diff-9b2ba253038f7b71dbbbcb545e028d2d51d27d88b041b918c9eb102a83fef189R117 causing incompatiblity with the type defined in this repository.

By using types exported from the `vue` package instead of defining our own, we can avoid similar breakges in the future.

`VNodeChild` type has been available since 3.0.0-beta.1.