### PR TITLE
Do not trim text content of the element

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,9 +128,7 @@ export function isObjectComponent(
 export function textContent(element: Node): string {
   // we check if the element is a comment first
   // to return an empty string in that case, instead of the comment content
-  return element.nodeType !== Node.COMMENT_NODE
-    ? element.textContent?.trim() ?? ''
-    : ''
+  return element.nodeType !== Node.COMMENT_NODE ? element.textContent ?? '' : ''
 }
 
 export function hasOwnProperty<O extends {}, P extends PropertyKey>(

--- a/tests/components/FunctionComponent.tsx
+++ b/tests/components/FunctionComponent.tsx
@@ -4,7 +4,7 @@ interface Props {
   title: string
 }
 const Title: FunctionalComponent<Props> = ({ title }) => {
-  return <h1> {title} </h1>
+  return <h1>{title}</h1>
 }
 Title.props = {
   title: String

--- a/tests/text.spec.ts
+++ b/tests/text.spec.ts
@@ -113,4 +113,12 @@ describe('text', () => {
 
     expect(wrapper.text()).toBe('Text content')
   })
+
+  it('does not trim content when separated in multiple independent elements', () => {
+    const wrapper = mount({
+      template: `<span>Trimmed </span><span>Example</span>`
+    })
+
+    expect(wrapper.text()).toBe('Trimmed Example')
+  })
 })


### PR DESCRIPTION
This is a fix for the regression found in #2251 

I removed the trim that was used inside the textContent function. I think it is more understandable for people as it is not doing unexpected things and better matches the description of the documentation : https://test-utils.vuejs.org/api/#text
I also added a test reproducing the regression mentionned in #2251 so that it avoid coming back in the future.

Obviously this pull request is a breaking change for people that were relying on this trim logic (that was not documented anyway)