### PR TITLE
WIP: Fix for issue 2261

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { DOMWrapper } from './domWrapper'
 import { VueWrapper } from './vueWrapper'
 import BaseWrapper from './baseWrapper'
 import { mount, shallowMount } from './mount'
-import { renderToString } from './renderToString'
+import { renderToString as _renderToString } from './renderToString'
 import { MountingOptions } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { createWrapperError } from './errorWrapper'
@@ -10,6 +10,9 @@ import { config } from './config'
 import { flushPromises } from './utils/flushPromises'
 import { enableAutoUnmount, disableAutoUnmount } from './utils/autoUnmount'
 
+// is __SSR__ avaialble? If so, preferable to use that?
+const isNode = typeof window === 'undefined'
+const renderToString = ( isNode ?  _renderToString  : null)
 export {
   mount,
   shallowMount,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import { config } from './config'
 import { flushPromises } from './utils/flushPromises'
 import { enableAutoUnmount, disableAutoUnmount } from './utils/autoUnmount'
 
-// is __SSR__ avaialble? If so, preferable to use that?
 const isNode = typeof window === 'undefined'
 const renderToString = ( isNode ?  _renderToString  : null)
 export {

--- a/tests/index.jsdom.spec.ts
+++ b/tests/index.jsdom.spec.ts
@@ -1,0 +1,10 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+
+import * as exports from '../src/index'
+describe('index.js exports', () => {
+  it('in a browser environment renderToString should not be exported', () => {
+    // data type of null is object
+    expect(typeof exports.renderToString).toEqual('object');
+  });
+})

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,0 +1,9 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest'
+
+import * as exports from '../src/index'
+describe('index.js exports', () => {
+  it('in a node environment renderToString should be exported', () => {
+    expect(typeof exports.renderToString).toEqual('function');
+  });
+})


### PR DESCRIPTION
Work in progress

https://github.com/vuejs/test-utils/issues/2261

## Cause:
- ssrUtils is not available in the esm-browser version of Vue. However, Vue Test Utils uses it for renderToString.

## Fix
- "guard" this renderToString function to avoid shipping it in the esm-browser version of VTU, as Vue does: https://github.com/vuejs/core/blob/2cece5ba1b9b254cface23096d17ed0e1910467d/packages/runtime-core/src/index.ts#L351


### Notes
- Entrypoints defined here https://github.com/Sandbagger/test-utils/blob/cd4903e9017d6f3eda3f537a8aca6e01bbab5763/rollup.config.ts#L84 (all use 'src/index.ts')

