### PR TITLE
fix: always load cjs bundle in node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "node": "./dist/vue-test-utils.cjs.js",
       "import": "./dist/vue-test-utils.esm-bundler.mjs",
       "browser": "./dist/vue-test-utils.browser.js",
       "require": "./dist/vue-test-utils.cjs.js",


### PR DESCRIPTION
at the moment the subpath import condition for `import` loads a 'bundler' version which expects a browser environment (it references `document`). But node running in a native ESM context will also resolve this condition.

To fix simply, we can inject a `node` condition in front of it which will force node to use the CJS version.

Longer term, I would recommend _also_ producing an ESM version that does not rely on a browser context.