### PR TITLE
fix: experimentalVmThreads is now pool=vmThreads

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    experimentalVmThreads: true,
+    pool: 'vmThreads',
     setupFiles: [path.resolve(__dirname, './setup.js')],
     include: ['tests/**/*.spec.ts'],
     server: {


### PR DESCRIPTION
It changed in vitest v1 https://vitest.dev/guide/migration.html#pools-are-standardized-4172