### PR TITLE
docs(api): fix typo in attachTo anchor tag within isVisible

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1436,7 +1436,7 @@ isVisible(): boolean
 **Details:**
 
 ::: warning
-`isVisible()` only works correctly if the wrapper is attached to the DOM using [`attachTo`](#attachto)
+`isVisible()` only works correctly if the wrapper is attached to the DOM using [`attachTo`](#attachTo)
 :::
 
 ```js

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1445,9 +1445,11 @@ const Component = {
 }
 
 test('isVisible', () => {
-  const wrapper = mount(Component)
+  const wrapper = mount(Component, {
+    attachTo: document.body
+  });
 
-  expect(wrapper.find('span').isVisible()).toBe(false)
+  expect(wrapper.find('span').isVisible()).toBe(false);
 })
 ```
 

--- a/docs/fr/api/index.md
+++ b/docs/fr/api/index.md
@@ -1429,13 +1429,19 @@ isVisible(): boolean
 
 **Utilisation&nbsp;:**
 
+::: warning
+`isVisible()` ne fonctionne correctement que si le wrapper est attaché au DOM en utilisant [`attachTo`](#attachTo)
+:::
+
 ```js
 const Component = {
   template: `<div v-show="false"><span /></div>`,
 };
 
 test('isVisible', () => {
-  const wrapper = mount(Component);
+  const wrapper = mount(Component, {
+    attachTo: document.body
+  });
 
   expect(wrapper.find('span').isVisible()).toBe(false);
 });


### PR DESCRIPTION
There is a typo in the anchor tag that links from the isVisible documentation to the attachTo documentation.