### PR TITLE
fix: renderStubDefaultSlot with scoped slots

### DIFF
--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -117,8 +117,13 @@ export const createStub = ({
         // Also having function text as attribute is useless and annoying so
         // we replace it with "[Function]""
         const stubProps = normalizeStubProps(props)
-
-        return h(tag, stubProps, renderStubDefaultSlot ? slots : undefined)
+        // if renderStubDefaultSlot is true, we render the default slot
+        if (renderStubDefaultSlot && slots.default) {
+          // we explicitly call the default slot with an empty object
+          // so scope slots destructuring works
+          return h(tag, stubProps, slots.default({}))
+        }
+        return h(tag, stubProps)
       }
     }
   })

--- a/tests/mountingOptions/global.components.spec.ts
+++ b/tests/mountingOptions/global.components.spec.ts
@@ -72,6 +72,7 @@ describe('global.components', () => {
     spy.mockRestore()
     expect(wrapper.text()).toBe('Global')
   })
+
   it('render children with shallow and renderStubDefaultSlot', () => {
     const Child = defineComponent({
       template: '<div><p>child</p><slot /></div>'
@@ -93,6 +94,35 @@ describe('global.components', () => {
       '<div>\n' +
         '  <child-stub>\n' +
         '    <div>hello</div>\n' +
+        '  </child-stub>\n' +
+        '</div>'
+    )
+  })
+
+  // https://github.com/vuejs/test-utils/issues/2395
+  it('render children with shallow and renderStubDefaultSlot with v-slot', () => {
+    const Child = defineComponent({
+      template: '<div><p>child</p><slot /></div>'
+    })
+    const Component = defineComponent({
+      template:
+        '<div><Child v-slot="{ count }"><div>hello{{ count }}there</div></Child></div>',
+      components: {
+        Child
+      }
+    })
+    const wrapper = mount(Component, {
+      shallow: true,
+      global: {
+        renderStubDefaultSlot: true
+      }
+    })
+
+    // count is undefined, but doesn't throw an error
+    expect(wrapper.html()).toEqual(
+      '<div>\n' +
+        '  <child-stub>\n' +
+        '    <div>hellothere</div>\n' +
         '  </child-stub>\n' +
         '</div>'
     )


### PR DESCRIPTION
Fixes #2395

We now explicitely call the default slot with an empty object to ensure that `<ComponentWithSlot v-slot="{ count }">` won't throw when tested with `renderStubDefaultSlot`.