### PR TITLE
docs: fix missing equal sign

### DIFF
--- a/docs/guide/advanced/v-model.md
+++ b/docs/guide/advanced/v-model.md
@@ -27,7 +27,7 @@ const Editor = {
 This component will just behave as an input component:
 
 ```js
-const App {
+const App = {
   components: {
     Editor
   },


### PR DESCRIPTION
missing a equal sign in [Testing v-model](https://test-utils.vuejs.org/guide/advanced/v-model.html#A-Simple-Example):

```js
const App {
  components: {
    Editor
  },
}
```
change to:

```js
const App = {
  components: {
    Editor
  },
}
```
