### PR TITLE
docs(api): fix missing chars

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -829,7 +829,7 @@ test('shallow', () => {
   const wrapper = mount(Component, { shallow: true })
 
   expect(wrapper.html()).toEqual(
-    `<a-component-stub></a-component-stub><another-component></another-component>`
+    `<a-component-stub></a-component-stub><another-component-stub></another-component-stub>`
   )
 }
 ```

--- a/docs/fr/api/index.md
+++ b/docs/fr/api/index.md
@@ -825,7 +825,7 @@ test('shallow', () => {
   const wrapper = mount(Component, { shallow: true });
 
   expect(wrapper.html()).toEqual(
-    `<a-component-stub></a-component-stub><another-component></another-component>`,
+    `<a-component-stub></a-component-stub><another-component-stub></another-component-stub>`,
   );
 });
 ```


### PR DESCRIPTION
The example of the [shallow](https://test-utils.vuejs.org/api/#shallow) API misses the suffix "stub" when making assertions. 

`Component.spec.js`
```js
import { mount } from '@vue/test-utils'
import Component from './Component.vue'

test('shallow', () => {
  const wrapper = mount(Component, { shallow: true })

  expect(wrapper.html()).toEqual(
    `<a-component-stub></a-component-stub><another-component></another-component>`
  )
}
```
should change to:
```js
import { mount } from '@vue/test-utils'
import Component from './Component.vue'

test('shallow', () => {
  const wrapper = mount(Component, { shallow: true })

  expect(wrapper.html()).toEqual(
    `<a-component-stub></a-component-stub><another-component-stub></another-component-stub>`
  )
}
```