### PR TITLE
docs: use innerHTML in teleport cleanup

### DIFF
--- a/docs/fr/guide/advanced/teleport.md
+++ b/docs/fr/guide/advanced/teleport.md
@@ -101,7 +101,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // nous nettoyons un peu
-  document.body.outerHTML = '';
+  document.body.innerHTML = '';
 });
 
 test('teleport', async () => {
@@ -174,7 +174,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // nous nettoyons un peu
-  document.body.outerHTML = '';
+  document.body.innerHTML = '';
 });
 
 test('teleport', async () => {

--- a/docs/guide/advanced/teleport.md
+++ b/docs/guide/advanced/teleport.md
@@ -100,7 +100,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // clean up
-  document.body.outerHTML = ''
+  document.body.innerHTML = ''
 })
 
 test('teleport', async () => {
@@ -173,7 +173,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // clean up
-  document.body.outerHTML = ''
+  document.body.innerHTML = ''
 })
 
 test('teleport', async () => {

--- a/tests/docs-examples/teleport.spec.ts
+++ b/tests/docs-examples/teleport.spec.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // clean up
-  document.body.outerHTML = ''
+  document.body.innerHTML = ''
 })
 
 test('teleport', async () => {


### PR DESCRIPTION
closes #2402

Updated `tests/docs-examples/teleport.spec.ts`; `tests/features/teleport.spec.ts` is still using `outerHTML` though.