### PR TITLE
fix(stubs): avoid warning on normalized props with Vue v3.4.22

### DIFF
--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -47,10 +47,10 @@ const normalizeStubProps = (props: ComponentPropsOptions) => {
   const $props = props as unknown as ComponentObjectPropsOptions
   return Object.keys($props).reduce((acc, key) => {
     if (typeof $props[key] === 'symbol') {
-      return { ...acc, [key]: $props[key]?.toString() }
+      return { ...acc, [key]: [$props[key]?.toString()] }
     }
     if (typeof $props[key] === 'function') {
-      return { ...acc, [key]: '[Function]' }
+      return { ...acc, [key]: ['[Function]'] }
     }
     return { ...acc, [key]: $props[key] }
   }, {})

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mount, shallowMount, VueWrapper } from '../src'
 import WithProps from './components/WithProps.vue'
 import PropWithSymbol from './components/PropWithSymbol.vue'
@@ -316,6 +316,20 @@ describe('props', () => {
     })
 
     expect(wrapper.html()).toBe('<comp-stub fn="[Function]"></comp-stub>')
+  })
+
+  // https://github.com/vuejs/test-utils/issues/2411
+  it('should not warn on stringify props in stubs', () => {
+    const spy = vi.spyOn(console, 'warn').mockReturnValue()
+    const Comp = defineComponent({
+      name: 'Comp',
+      template: `<transition @enter="() => {}"></transition>`
+    })
+
+    const wrapper = mount(Comp)
+
+    expect(wrapper.html()).toContain('<transition-stub')
+    expect(spy).not.toHaveBeenCalled()
   })
 
   describe('edge case with symbol props and stubs', () => {


### PR DESCRIPTION
Fixes #2411

We can "trick" the warning introduced in Vue v3.4.22 (See https://github.com/vuejs/core/commit/7ccd453dd004076cad49ec9f56cd5fe97b7b6ed8) by using an array of strings instead of a string (as the new check allows functions and arrays, but not strings). This does not affect the rendering of the stub, and still displays `[Function]`, so it should not impact the existing tests.