### PR TITLE
chore: use the packageManager field from package.json in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install pnpm
       uses: pnpm/action-setup@v3.0.0
-      with:
-        version: 8.6.3
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
This is the default behavior when the version is not specified, allowing to have the same version without updating it in two places.