### PR TITLE
Update index.md to fix typo and clarify `get` vs `find` behavior

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1278,9 +1278,9 @@ get(selector: string): Omit<DOMWrapper<Element>, 'exists'>
 
 **Details:**
 
-It is similar to `find`, but `get` throws instead of returning a ErrorWrapper.
+It is similar to `find`, but `get` throws an error if an element is not found while [`find`](#find) will return an ErrorWrapper.
 
-As a rule of thumb, always use get except when you are asserting something doesn't exist. In that case use [`find`](#find).
+As a rule of thumb, always use `get` except when you are asserting something doesn't exist. In that case use [`find`](#find).
 
 `Component.vue`:
 


### PR DESCRIPTION
Update index.md to fix typo and clarify `get` vs `find` behavior differences

Saw that there was a typo while reading the docs myself and thought I should contribute. Change is minor.