### PR TITLE
fix: set global provides before running vue plugins

### DIFF
--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -266,6 +266,14 @@ export function createInstance(
     }
   }
 
+  // provide any values passed via provides mounting option
+  if (global.provide) {
+    for (const key of Reflect.ownKeys(global.provide)) {
+      // @ts-ignore: https://github.com/microsoft/TypeScript/issues/1863
+      app.provide(key, global.provide[key])
+    }
+  }
+
   // use and plugins from mounting options
   if (global.plugins) {
     for (const plugin of global.plugins) {
@@ -294,14 +302,6 @@ export function createInstance(
   if (global.directives) {
     for (const key of Object.keys(global.directives))
       app.directive(key, global.directives[key])
-  }
-
-  // provide any values passed via provides mounting option
-  if (global.provide) {
-    for (const key of Reflect.ownKeys(global.provide)) {
-      // @ts-ignore: https://github.com/microsoft/TypeScript/issues/1863
-      app.provide(key, global.provide[key])
-    }
   }
 
   // stubs


### PR DESCRIPTION
Happy to have some push-back on this, but encountered a situation in `@nuxt/test-utils` where we set default 'provides' but would like the user to be able to register their own plugins to override these (https://github.com/nuxt/test-utils/issues/828).

Reordering the provides before the plugins seems like a reasonable way to do this, but happy for other ideas, or to try to tackle this downstream instead if you don't like the change or it breaks something.