### PR TITLE
Fix/issue 2319 throw first error thrown during mount

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -74,9 +74,9 @@ export function mount(
   // Workaround for https://github.com/vuejs/core/issues/7020
   const originalErrorHandler = app.config.errorHandler
 
-  let errorOnMount = null
+  let errorsOnMount: unknown[] = []
   app.config.errorHandler = (err, instance, info) => {
-    errorOnMount = err
+    errorsOnMount.push(err)
 
     return originalErrorHandler?.(err, instance, info)
   }
@@ -100,9 +100,9 @@ export function mount(
     to.appendChild(el)
   }
   const vm = app.mount(el)
-
-  if (errorOnMount) {
-    throw errorOnMount
+  if (errorsOnMount.length) {
+    // If an error is thrown, throw the first error.
+    throw errorsOnMount[0]
   }
   app.config.errorHandler = originalErrorHandler
 

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -101,7 +101,7 @@ export function mount(
   }
   const vm = app.mount(el)
   if (errorsOnMount.length) {
-    // If an error is thrown, throw the first error.
+    // If several errors are thrown during mount, then throw the first one
     throw errorsOnMount[0]
   }
   app.config.errorHandler = originalErrorHandler

--- a/tests/mount.spec.ts
+++ b/tests/mount.spec.ts
@@ -27,7 +27,16 @@ describe('mount: general tests', () => {
 
     expect(wrapper.html()).toBe('<div>hello</div>')
   })
+  it('if an error is thrown during mounting, the first error is thrown.', () => {
+    const ThrowingComponent = defineComponent({
+      setup() {
+        throw new Error('Boom!')
+      },
+      template: '<div>{{ x.y }}</div>'
+    })
 
+    expect(() => mount(ThrowingComponent)).toThrowError('Boom!')
+  })
   it('should not warn on readonly hasOwnProperty when mounting a component', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 

--- a/tests/mount.spec.ts
+++ b/tests/mount.spec.ts
@@ -27,7 +27,8 @@ describe('mount: general tests', () => {
 
     expect(wrapper.html()).toBe('<div>hello</div>')
   })
-  it('if an error is thrown during mounting, the first error is thrown.', () => {
+
+  it('should throw the first error encountered when mounting the component', () => {
     const ThrowingComponent = defineComponent({
       setup() {
         throw new Error('Boom!')
@@ -37,6 +38,7 @@ describe('mount: general tests', () => {
 
     expect(() => mount(ThrowingComponent)).toThrowError('Boom!')
   })
+
   it('should not warn on readonly hasOwnProperty when mounting a component', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 


### PR DESCRIPTION
resolve #2319

Changed so that if an error is thrown during mounting, the first error is thrown