### PR TITLE
ci: remove node v22 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18, 20, 22]
+        node: [18, 20]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Node v22 is currently failing with segfault, so let's disable it temporarily