### PR TITLE
add test cases for JSX components

### DIFF
--- a/tests/components/ComponentWithoutNameJsx.tsx
+++ b/tests/components/ComponentWithoutNameJsx.tsx
@@ -1,0 +1,7 @@
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  setup() {
+    return () => <div class="ComponentWithoutNameJsx">No Name JSX</div>
+  }
+})

--- a/tests/components/HelloJsx.tsx
+++ b/tests/components/HelloJsx.tsx
@@ -1,0 +1,14 @@
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  name: 'HelloJsx',
+  setup() {
+    const msg = ref('Hello World')
+
+    return () => (
+      <div id="root">
+        <div id="msg">{msg}</div>
+      </div>
+    )
+  }
+})

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -6,6 +6,7 @@ import ComponentWithoutName from '../components/ComponentWithoutName.vue'
 import ComponentWithSlots from '../components/ComponentWithSlots.vue'
 import ScriptSetupWithChildren from '../components/ScriptSetupWithChildren.vue'
 import AutoImportScriptSetup from '../components/AutoImportScriptSetup.vue'
+import HelloJsx from '../components/HelloJsx'
 
 describe('mounting options: stubs', () => {
   let configStubsSave = config.global.stubs
@@ -99,6 +100,36 @@ describe('mounting options: stubs', () => {
     expect(wrapper.html()).toEqual(
       '<div>\n' + '  <foo-stub></foo-stub>\n' + '</div>'
     )
+  })
+
+  it('stubs a Hello SFC component from render function', () => {
+    const Comp = {
+      render: () => h(Hello)
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          Hello: true
+        }
+      }
+    })
+
+    expect(wrapper.html()).toEqual('<hello-stub></hello-stub>')
+  })
+
+  it('stubs a JSX component with name', () => {
+    const Comp = {
+      render: () => h(HelloJsx)
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          HelloJsx: true
+        }
+      }
+    })
+
+    expect(wrapper.html()).toEqual('<hello-jsx-stub></hello-jsx-stub>')
   })
 
   it('passes all attributes to stubbed components', () => {

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -7,6 +7,7 @@ import ComponentWithSlots from '../components/ComponentWithSlots.vue'
 import ScriptSetupWithChildren from '../components/ScriptSetupWithChildren.vue'
 import AutoImportScriptSetup from '../components/AutoImportScriptSetup.vue'
 import HelloJsx from '../components/HelloJsx'
+import ComponentWithoutNameJsx from '../components/ComponentWithoutNameJsx'
 
 describe('mounting options: stubs', () => {
   let configStubsSave = config.global.stubs
@@ -99,6 +100,25 @@ describe('mounting options: stubs', () => {
 
     expect(wrapper.html()).toEqual(
       '<div>\n' + '  <foo-stub></foo-stub>\n' + '</div>'
+    )
+  })
+
+  it('stubs a JSX component without a name', () => {
+    const Comp = {
+      render: () => h(() => [h(ComponentWithoutNameJsx)])
+    }
+    const wrapper = mount(Comp, {
+      global: {
+        stubs: {
+          ComponentWithoutNameJsx: true
+        }
+      }
+    })
+
+    expect(wrapper.html()).toEqual(
+      '<div>\n' +
+        '  <component-without-name-jsx-stub></component-without-name-jsx-stub>\n' +
+        '</div>'
     )
   })
 


### PR DESCRIPTION
This pull requests aims for fixing this issue: https://github.com/vuejs/test-utils/issues/2438

I added a failing unit test.
Unfortunately I didn't manage to fix the unit test and with that actually fix the issue I'm experiencing. Maybe someone knows how to finish this up?

What I'm missing is:
- My child component is not stubbed, because the transformer doesn't find any component for the given `type`.
- I don't know which one of these lines but at least one should find out the component name: https://github.com/julisch94/test-utils/blob/main/src/vnodeTransformers/stubComponentsTransformer.ts#L185-L186
- when I hardcode the name of my component there, it all works. So all I'm missing is:
- the transformer needs to be able to determine the component name inside my parent component
-  How can that be done?

Please feel free to help out!