### PR TITLE
chore: ignore TS error in config object

### DIFF
--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -260,6 +260,8 @@ export function createInstance(
       keyof Omit<AppConfig, 'isNativeTag'>,
       any
     ][]) {
+      // TODO should be switched to a ts-expect-error once Vue 3.5 is used
+      // @ts-ignore https://github.com/vuejs/test-utils/issues/2483
       app.config[k] = isObject(app.config[k])
         ? Object.assign(app.config[k]!, v)
         : v
@@ -269,6 +271,7 @@ export function createInstance(
   // provide any values passed via provides mounting option
   if (global.provide) {
     for (const key of Reflect.ownKeys(global.provide)) {
+      // TODO should be switched to a ts-expect-error
       // @ts-ignore: https://github.com/microsoft/TypeScript/issues/1863
       app.provide(key, global.provide[key])
     }


### PR DESCRIPTION
Fixes #2483

The introduction of `idPrefix` in Vue's `AppConfig` object triggers a TS error that we can't really get rid of (see #2483 for a more detailled explanation).