### PR TITLE
chore(index): exposing Stubs type for declaration files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { VueWrapper } from './vueWrapper'
 import BaseWrapper from './baseWrapper'
 import { mount, shallowMount } from './mount'
 import { renderToString } from './renderToString'
-import { MountingOptions } from './types'
+import { MountingOptions, Stubs } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { createWrapperError } from './errorWrapper'
 import { config } from './config'
@@ -23,6 +23,7 @@ export {
   config,
   flushPromises,
   MountingOptions,
+  Stubs,
   createWrapperError
 }
 


### PR DESCRIPTION
### Exposes `Stubs` over `index.d.ts` for ease of use on developers.

Being `Stubs` an existing type on test-utils, and having to import declarations on test files, this PR helps to remove boilerplate to always declare something along the lines of:

```typescript
import { RouterLinkStub } from '@vue/test-utils';

interface SetupProps {
  props: MyComponentProps;
  stubs: Record<string, boolean | typeof RouterLInkStub>;
}

function setup({ props = {}, stubs = {} }: SetupProps = {}) {
  render(MyComponent, {
    global: { stubs },
    props,
  });
}


test('something', () => {
  setup({ stubs: { 'router-link': RouterLinkStub, MyModal: true } });

  expect(screen.getByText('foo')).toBeDefined();
});
```

or setting up manually Component or DIrective types from vue itself:

```typescript
import { RouterLinkStub } from '@vue/test-utils';
import { Component, Directive } from 'vue';

interface SetupProps {
  props: MyComponentProps;
  stubs: Record<string, boolean | Component | Directive>;
}

function setup({ props = {}, stubs = {} }: SetupProps = {}) {
  render(MyComponent, {
    global: { stubs },
    props,
  });
}


test('something', () => {
  setup({ stubs: { 'router-link': RouterLinkStub, MyModal: true } });

  expect(screen.getByText('foo')).toBeDefined();
});
```

In this second case, this `Record<string, boolean | Component | Directive>`, [is basically what type `Stubs` is](https://github.com/vuejs/test-utils/blob/ab4df74d80186f990d2bd349cbc1cdcdd9e0a031/src/types.ts#L110-L111):

```typescript
export type Stub = boolean | Component | Directive
export type Stubs = Record<string, Stub> | Array<string>
```

That could simplify the import boilerplate into:

```typescript
import { RouterLinkStub, Stubs } from '@vue/test-utils';

interface SetupProps {
  props: MyComponentProps;
  stubs: Stubs;
}

function setup({ props = {}, stubs = {} }: SetupProps = {}) {
  render(MyComponent, {
    global: { stubs },
    props,
  });
}


test('something', () => {
  setup({ stubs: { 'router-link': RouterLinkStub, MyModal: true } });

  expect(screen.getByText('foo')).toBeDefined();
});
```

for a cleaner experience.