### PR TITLE
fixed incorrect checkbox value check

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1691,10 +1691,10 @@ test('setValue on checkbox', async () => {
   const wrapper = mount(Component)
 
   await wrapper.find('input[type="checkbox"]').setValue(true)
-  expect(wrapper.find('div')).toBe(true)
+  expect(wrapper.find('div').exists()).toBe(true)
 
   await wrapper.find('input[type="checkbox"]').setValue(false)
-  expect(wrapper.find('div')).toBe(false)
+  expect(wrapper.find('div').exists()).toBe(false)
 })
 
 test('setValue on input text', async () => {

--- a/docs/fr/api/index.md
+++ b/docs/fr/api/index.md
@@ -1683,10 +1683,10 @@ test('setValue sur une checkbox', async () => {
   const wrapper = mount(Component);
 
   await wrapper.find('input[type="checkbox"]').setValue(true);
-  expect(wrapper.find('div')).toBe(true);
+  expect(wrapper.find('div').exists()).toBe(true);
 
   await wrapper.find('input[type="checkbox"]').setValue(false);
-  expect(wrapper.find('div')).toBe(false);
+  expect(wrapper.find('div').exists()).toBe(false);
 });
 
 test('setValue sur un champ texte', async () => {


### PR DESCRIPTION
This PR fixes an issue where the code incorrectly treated wrapper.find('div') as a boolean value.

**Changes Made**
Replaced expect(wrapper.find('div')).toBe(true) with expect(wrapper.find('div').exists()).toBe(true)