### PR TITLE
Fix/issue 2462 - Vue is not defined in projects using Webpack and in-browser testing solutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
       "types": "./dist/index.d.ts",
       "node": "./dist/vue-test-utils.cjs.js",
       "import": "./dist/vue-test-utils.esm-bundler.mjs",
-      "browser": "./dist/vue-test-utils.browser.js",
       "require": "./dist/vue-test-utils.cjs.js",
+      "browser": "./dist/vue-test-utils.browser.js",
       "default": "./dist/vue-test-utils.cjs.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
This PR resolves #2462 

Should also resolve #234 even though a bit late now ;-)

Simply inverts `browser` and `require` exports definition inside `package.json` so that `Webpack`-powered projects running tests in a browser context (and not in Node) take the correct build while bundling.  
See #2462 for detailed discussions.