### PR TITLE
fix: re-add peer dependencies but with wider range (#2507)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,15 @@
     "vue-tsc": "2.1.6",
     "vuex": "4.1.0"
   },
+  "peerDependencies": {
+    "@vue/server-renderer": "3.x",
+    "vue": "3.x"
+  },
+  "peerDependenciesMeta": {
+    "@vue/server-renderer": {
+      "optional": true
+    }
+  },
   "author": {
     "name": "Lachlan Miller",
     "email": "lachlan.miller.1990@outlook.com"


### PR DESCRIPTION
- no peer dependencies causes @vue/test-utils to import stuff from the wrong Vue version in monorepos with multiple Vue versions
- too specific peer dependencies causes dependant projects not to be updated or find a valid Vue version so the range has been widened

closes 2507