### PR TITLE
import missing DOMWrapper on Implementation of Data Test ID Plugin

### DIFF
--- a/docs/guide/extending-vtu/plugins.md
+++ b/docs/guide/extending-vtu/plugins.md
@@ -103,7 +103,7 @@ wrapper.findByTestId('name-input') // returns a VueWrapper or DOMWrapper
 Implementation of the plugin:
 
 ```js
-import { config } from '@vue/test-utils'
+import { config, DOMWrapper} from '@vue/test-utils'
 
 const DataTestIdPlugin = (wrapper) => {
   function findByTestId(selector) {


### PR DESCRIPTION
just followed the implementation of [Data Test ID Plugin section guide ](https://test-utils.vuejs.org/guide/extending-vtu/plugins.html#Data-Test-ID-Plugin)and notice that actually the DOMWrapper was not being imported.

![image](https://github.com/user-attachments/assets/c7f52682-d298-40d8-aa21-05de8a22b724)
