### PR TITLE
fix: resolve warnings in docs:dev

### DIFF
--- a/tests/components/PropWithSymbol.vue
+++ b/tests/components/PropWithSymbol.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>Symbol: {{ $props.sym }}</div>
+  <div>Symbol: {{ sym }}</div>
 </template>
 
 <script lang="ts" setup>
@@ -7,7 +7,5 @@ interface Props {
   sym?: Symbol
 }
 
-withDefaults(defineProps<Props>(), {
-  sym: () => Symbol()
-})
+const { sym = Symbol() } = defineProps<Props>()
 </script>


### PR DESCRIPTION
### Description

This modification aims to resolve warnings encountered when running `docs:dev` :
![image](https://github.com/user-attachments/assets/e3375556-a5dd-40df-8fc6-b9cc43e7b214)

We are now using Vue 3.5+, so `withDefaults` is [unnecessary](https://vuejs.org/api/sfc-script-setup.html#defineprops-defineemits).