### PR TITLE
fix: resolve TypeScript type errors in .vitepress/config

### DIFF
--- a/docs/.vitepress/config/en.mts
+++ b/docs/.vitepress/config/en.mts
@@ -1,10 +1,10 @@
-import type { DefaultTheme, LocalSpecificConfig } from 'vitepress'
+import type { DefaultTheme, LocaleSpecificConfig } from 'vitepress'
 
 export const META_URL = ''
 export const META_TITLE = 'Vue Test Utils'
 export const META_DESCRIPTION = 'The official testing suite utils for Vue.js 3'
 
-export const enConfig: LocalSpecificConfig<DefaultTheme.config> = {
+export const enConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
   description: META_DESCRIPTION,
   head: [
     ['meta', { property: 'og:url', content: META_URL }],
@@ -39,7 +39,6 @@ export const enConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Essentials',
-          collapsable: false,
           items: [
             { text: 'Getting Started', link: '/guide/' },
             { text: 'A Crash Course', link: '/guide/essentials/a-crash-course' },
@@ -64,7 +63,6 @@ export const enConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Vue Test Utils in depth',
-          collapsable: false,
           items: [
             { text: 'Slots', link: '/guide/advanced/slots' },
             {
@@ -97,7 +95,6 @@ export const enConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Extending Vue Test Utils',
-          collapsable: false,
           items: [
             { text: 'Plugins', link: '/guide/extending-vtu/plugins' },
             {

--- a/docs/.vitepress/config/fr.mts
+++ b/docs/.vitepress/config/fr.mts
@@ -1,10 +1,10 @@
-import type { DefaultTheme, LocalSpecificConfig } from 'vitepress'
+import type { DefaultTheme, LocaleSpecificConfig } from 'vitepress'
 
 export const META_URL = ''
 export const META_TITLE = 'Vue Test Utils'
 export const META_DESCRIPTION = 'La librairie officielle de tests unitaires pour Vue.js 3'
 
-export const frConfig: LocalSpecificConfig<DefaultTheme.config> = {
+export const frConfig: LocaleSpecificConfig<DefaultTheme.Config> = {
   description: META_DESCRIPTION,
   head: [
     ['meta', { property: 'og:url', content: META_URL }],
@@ -43,7 +43,6 @@ export const frConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Les Bases',
-          collapsable: false,
           items: [
             { text: 'Pour commencer', link: '/fr/guide/' },
             { text: 'Cours rapide', link: '/fr/guide/essentials/a-crash-course' },
@@ -68,7 +67,6 @@ export const frConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Vue Test Utils en détail',
-          collapsable: false,
           items: [
             { text: 'Slots', link: '/fr/guide/advanced/slots' },
             {
@@ -101,7 +99,6 @@ export const frConfig: LocalSpecificConfig<DefaultTheme.config> = {
         },
         {
           text: 'Extensions de Vue Test Utils',
-          collapsable: false,
           items: [
             { text: 'Plugins', link: '/fr/guide/extending-vtu/plugins' },
             {


### PR DESCRIPTION
### Before
There are some TypeScript type errors in the `.vitepress/config` directory ：
![image](https://github.com/user-attachments/assets/c90bc523-cb62-46f3-afe5-f8b55154bcea)

### Description
This PR addresses and resolves TypeScript type errors found in the `.vitepress/config` directory.
And the `collapsable` configuration has been removed in this [vitepress PR](https://github.com/vuejs/vitepress/pull/1865/files#diff-08d1bb1c444a76199b8f44b087883f932a6f8118f5ded25bf5c508fa52aa5b7f), replaced by the new property `collapsed`, so I removed the unnecessary `collapsable` configuration.