### PR TITLE
docs: perf site home

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,8 @@
+.VPContent {
+  display: flex;
+  align-items: center;
+}
+
+.VPHome {
+  flex-grow: 1;
+}

--- a/docs/.vitepress/theme/index.mts
+++ b/docs/.vitepress/theme/index.mts
@@ -2,7 +2,7 @@ import { h } from 'vue'
 import Theme from 'vitepress/theme'
 import TranslationStatus from 'vitepress-translation-helper/ui/TranslationStatus.vue'
 import status from '../translation-status.json'
-
+import './custom.css'
 const i18nLabels = {
   fr: 'La traduction est synchronisée avec les docs du ${date} dont le hash du commit est <code>${hash}</code>.',
 }


### PR DESCRIPTION
This is just a embellishment of personal opinion and can be closed directly if it is not adopted.

I would also like to add a code block to show the installation commands, but that would be a long theme customization, so I can try to implement it if you like.
![image](https://github.com/user-attachments/assets/c04c7bfd-7972-4699-96bc-5c9354858d12)

![image](https://github.com/user-attachments/assets/c9e9216b-6f28-48b7-bc38-628a73a3b6b1)
