### PR TITLE
docs(zh): 更新 Vitest 模拟日期和计时器的说明

### DIFF
--- a/docs/zh/guide/faq/index.md
+++ b/docs/zh/guide/faq/index.md
@@ -2,11 +2,11 @@
 
 [[toc]]
 
-## 使用 Vitest 模拟日期和定时器
+## 使用 Vitest 模拟日期和计时器
 
-Vue 的调度器依赖于系统时间。在调用 `vi.setSystemTime` 之后再挂载组件，因为 Vue 依赖于其副作用。在调用 `vi.setSystemTime` 之前挂载组件可能会导致响应性中断。
+Vue 的调度器依赖于系统时间。确保在调用 `vi.setSystemTime` 后再挂载组件，因为 Vue 依赖于其副作用。在调用 `vi.setSystemTime` 之前挂载组件可能会导致响应性出现问题。
 
-请参见 [vuejs/test-utils#2074](https://github.com/vuejs/test-utils/issues/2074)。
+请查看 [vuejs/test-utils#2074](https://github.com/vuejs/test-utils/issues/2074)。
 
 ## Vue warn: Failed setting prop
 
@@ -15,18 +15,17 @@ Vue 的调度器依赖于系统时间。在调用 `vi.setSystemTime` 之后再�
 TypeError: Cannot set property prefix of #<Element> which has only a getter
 ```
 
-如果你使用 `shallowMount` 或 `stubs`，并且使用了与 [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element) 共享的属性名称，将会显示此警告。
+当您使用 `shallowMount` 或具有与 [`Element`](https://developer.mozilla.org/en-US/docs/Web/API/Element) 共享的属性名称的 `stubs` 时，会显示此警告。
 
 与 `Element` 共享的常见属性名称：
+* `attributes`
+* `children`
+* `prefix`
 
-- `attributes`
-- `children`
-- `prefix`
-
-请参见：https://developer.mozilla.org/en-US/docs/Web/API/Element
+请参阅：https://developer.mozilla.org/en-US/docs/Web/API/Element
 
 **可能的解决方案**
 
-1. 使用 `mount` 而不是 `shallowMount` 来渲染而不使用桩
+1. 使用 `mount` 而不是 `shallowMount` 进行不带存根的渲染
 2. 通过模拟 `console.warn` 来忽略警告
 3. 重命名 prop，以避免与 `Element` 属性冲突

--- a/docs/zh/guide/faq/index.md
+++ b/docs/zh/guide/faq/index.md
@@ -4,7 +4,7 @@
 
 ## 使用 Vitest 模拟日期和计时器
 
-Vue 的调度器依赖于系统时间。确保在调用 `vi.setSystemTime` 后再挂载组件，因为 Vue 依赖于其副作用。在调用 `vi.setSystemTime` 之前挂载组件可能会导致响应性出现问题。
+Vue 的调度器依赖于系统时间。请务必在调用 `vi.setSystemTime` 后再挂载组件，因为 Vue 依赖于其副作用。在调用 `vi.setSystemTime` 之前挂载组件可能会破坏其响应性。
 
 请查看 [vuejs/test-utils#2074](https://github.com/vuejs/test-utils/issues/2074)。
 
@@ -22,7 +22,7 @@ TypeError: Cannot set property prefix of #<Element> which has only a getter
 * `children`
 * `prefix`
 
-请参阅：https://developer.mozilla.org/en-US/docs/Web/API/Element
+请参阅：https://developer.mozilla.org/zh-CN/docs/Web/API/Element
 
 **可能的解决方案**
 


### PR DESCRIPTION
- 修改了文档中关于 Vitest 模拟日期和计时器的说明，强调在调用 vi.setSystemTime 后挂载组件的重要性
- 更新了相关警告的描述，使其更加清晰
- 修正了文档中的链接格式和部分翻译，提高了可读性
- https://github.com/vuejs/test-utils/issues/2561#issuecomment-2565101581