### PR TITLE
fix(stubs): Pass stubbed function to function props

### DIFF
--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -42,6 +42,9 @@ interface StubOptions {
   renderStubDefaultSlot?: boolean
 }
 
+function stubbedFunctionProp() {}
+stubbedFunctionProp.toString = () => '[Function]'
+
 const normalizeStubProps = (props: ComponentPropsOptions) => {
   // props are always normalized to object syntax
   const $props = props as unknown as ComponentObjectPropsOptions
@@ -51,7 +54,7 @@ const normalizeStubProps = (props: ComponentPropsOptions) => {
       return { ...acc, [key]: [value?.toString()] }
     }
     if (typeof value === 'function') {
-      return { ...acc, [key]: ['[Function]'] }
+      return { ...acc, [key]: [stubbedFunctionProp] }
     }
     return { ...acc, [key]: value }
   }, {})


### PR DESCRIPTION
The original implementation, added in
22c7698425f2745c573d6b8154e171e158449d8e, passed a string value to a function prop. This instead passes an actual function, which stringifies to the same string.

The problem with the previous approach is that Vue started warning about strings passed to function props in
https://github.com/vuejs/core/commit/7ccd453dd004076cad49ec9f56cd5fe97b7b6ed8. As a result, this produced excessive noise in the logs that the user can do nothing about.