### PR TITLE
docs(zh-cn): [event-handling.md] split comment into two lines to maintain syntax highlighting

### DIFF
--- a/docs/zh/guide/essentials/event-handling.md
+++ b/docs/zh/guide/essentials/event-handling.md
@@ -61,7 +61,8 @@ test('emits an event with count when clicked', () => {
   wrapper.find('button').trigger('click')
   wrapper.find('button').trigger('click')
 
-  // `emitted()` 接受一个参数。它返回一个包含所有 `this.$emit('increment')` 发生情况的数组。
+  // `emitted()` 接受一个参数。
+  // 它返回一个包含所有 `this.$emit('increment')` 发生情况的数组。
   const incrementEvent = wrapper.emitted('increment')
 
   // 我们“点击”了两次，所以 `increment` 的数组应该有两个值。


### PR DESCRIPTION
Thank you @lxKylin for the Chinese proofreading of the `event-handling.md` file in #2572, but one example's syntax highlighting did not match:

### Before:
![image](https://github.com/user-attachments/assets/c6624f3a-c433-46ac-9846-c3cb6a6bf119)
![image](https://github.com/user-attachments/assets/b91d1f73-e7f3-4645-b248-00514cefdf75)

### After:
![image](https://github.com/user-attachments/assets/46212ad0-3f2a-49f3-96b5-2a2bcd29dc03)

### Description
I think it's better not to change the original line numbers, as it will facilitate future updates.
我想还是不要改动到原有的行数，也方便后续更新