### PR TITLE
fix: use Teleport with disabled=true instead of stub

### DIFF
--- a/src/vnodeTransformers/util.ts
+++ b/src/vnodeTransformers/util.ts
@@ -85,7 +85,16 @@ export const createVNodeTransformer = ({
       registerStub({ source: originalType, stub: transformedType })
       // https://github.com/vuejs/test-utils/issues/1829 & https://github.com/vuejs/test-utils/issues/1888
       // Teleport/KeepAlive should return child nodes as a function
-      if (isTeleport(originalType) || isKeepAlive(originalType)) {
+      if (isTeleport(originalType)) {
+        return [
+          originalType,
+          { ...props, disabled: true },
+          children,
+          ...restVNodeArgs
+        ]
+      }
+
+      if (isKeepAlive(originalType)) {
         return [transformedType, props, () => children, ...restVNodeArgs]
       }
     }

--- a/tests/components/TeleportRemountChild.vue
+++ b/tests/components/TeleportRemountChild.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+
+const emit = defineEmits<{ myEvent: ['mount' | 'unmount'] }>()
+
+onMounted(() => {
+  emit('myEvent', 'mount')
+})
+
+onUnmounted(() => {
+  emit('myEvent', 'unmount')
+})
+</script>
+
+<template>
+  <span>child</span>
+</template>

--- a/tests/components/TeleportRemountParent.vue
+++ b/tests/components/TeleportRemountParent.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import Child from './TeleportRemountChild.vue'
+
+const parentValue = ref<Array<'mount' | 'unmount'>>([])
+
+const handleEmit = (e: 'mount' | 'unmount') => {
+  parentValue.value.push(e)
+}
+</script>
+<template>
+  <div>
+    <p id="parent-value">{{ JSON.stringify(parentValue) }}</p>
+    <Teleport to="#teleport-target">
+      <Child @my-event="handleEmit" />
+    </Teleport>
+  </div>
+</template>

--- a/tests/features/teleport.spec.ts
+++ b/tests/features/teleport.spec.ts
@@ -170,9 +170,9 @@ describe('teleport', () => {
 
     expect(wrapper.html()).toBe(
       '<div><button>Add</button>\n' +
-        '  <teleport-stub to="body">\n' +
-        '    <div id="count">1</div>\n' +
-        '  </teleport-stub>\n' +
+        '  <!--teleport start-->\n' +
+        '  <div id="count">1</div>\n' +
+        '  <!--teleport end-->\n' +
         '</div>'
     )
 


### PR DESCRIPTION
fixes #2628 

cc @Alevagre7

As part of #1889 the child of Teleport is wrapped with an arrow function. This aligns with how Vue expects it (that's why we don't have the warning anymore). However the stub doesn't use the same implementation for the Teleport as Vue does: Vue doesn't render the children, but waits for the Teleport component to be mounted, then render the children in the teleport target element.

Instead of using a stub, we have a proposal to utilize the `disabled` prop from the Vue API for the Teleport component (https://vuejs.org/guide/built-ins/teleport#disabling-teleport) instead of creating a custom stub for it.

By using the official API, we can rely on native functionality rather than introducing a stub, which can lead to more friction and increase the likelihood of errors. The `disabled` prop allows us to effectively "disable" the teleport behavior, which aligns with the intent behind stubbing—removing specific behavior from the unit test.

In essence, whenever someone creates a stub for a component, the goal is typically to abstract away its behavior during testing. Using the `disabled` prop achieves the same outcome in a cleaner and more reliable manner.

The implementation may not be the best, so @cexbrayat if you have suggestions for it we can change it.

Thanks!