### PR TITLE
ci: use "pool: threads" instead of vmThreads

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
-    pool: 'vmThreads',
+    pool: 'threads',
     setupFiles: [path.resolve(__dirname, './setup.js')],
     include: ['tests/**/*.spec.ts'],
     server: {


### PR DESCRIPTION
In the hope to get rid of the segfaults on ci