### PR TITLE
fix: use await in test

### DIFF
--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -344,7 +344,7 @@ describe('trigger', () => {
   })
 
   describe('errors', () => {
-    it('throws error if options contains a target value', () => {
+    it('throws error if options contains a target value', async () => {
       const expectedErrorMessage =
         '[vue-test-utils]: you cannot set the target value of an event. See the notes section of the docs for more details—https://vue-test-utils.vuejs.org/api/wrapper/trigger.html'
 
@@ -356,7 +356,7 @@ describe('trigger', () => {
       const wrapper = mount(Component, {})
 
       const fn = wrapper.trigger('click', { target: 'something' })
-      expect(fn).rejects.toThrowError(expectedErrorMessage)
+      await expect(fn).rejects.toThrowError(expectedErrorMessage)
 
       expect(clickHandler).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Removes the warning:
```
stderr | tests/trigger.spec.ts > trigger > errors > throws error if options contains a target value
Promise returned by `expect(actual).rejects.toThrowError(expected)` was not awaited. Vitest currently auto-awaits hanging assertions at the end of the test, but this will cause the test to fail in Vitest 3. Please remember to await the assertion.
```