### PR TITLE
Implement setData()/shallowMount with initialData for components using the Composition API / <script setup>

### DIFF
--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -9,7 +9,8 @@ import {
   ComponentOptions,
   ConcreteComponent,
   DefineComponent,
-  transformVNodeArgs
+  transformVNodeArgs,
+  proxyRefs
 } from 'vue'
 
 import { MountingOptions, Slot } from './types'
@@ -20,6 +21,7 @@ import {
   isObject,
   isObjectComponent,
   isScriptSetup,
+  mergeDeep,
   mergeGlobalProperties
 } from './utils'
 import { processSlot } from './utils/compileSlots'
@@ -163,7 +165,7 @@ export function createInstance(
         const originalSetupFn = objectComponent.setup
         objectComponent.setup = function (a, b) {
           const data = originalSetupFn(a, b)
-          Object.assign(data, providedData)
+          mergeDeep(proxyRefs(data), providedData)
           return data
         }
       } else {

--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -11,6 +11,7 @@ import {
   DefineComponent,
   transformVNodeArgs
 } from 'vue'
+import reactivity from '@vue/reactivity'
 
 import { MountingOptions, Slot } from './types'
 import {
@@ -20,6 +21,7 @@ import {
   isObject,
   isObjectComponent,
   isScriptSetup,
+  mergeDeep,
   mergeGlobalProperties
 } from './utils'
 import { processSlot } from './utils/compileSlots'
@@ -153,11 +155,22 @@ export function createInstance(
     if (isObjectComponent(originalComponent)) {
       // component is guaranteed to be the same type as originalComponent
       const objectComponent = component as ComponentOptions
-      const originalDataFn = originalComponent.data || (() => ({}))
-      objectComponent.data = (vm) => ({
-        ...originalDataFn.call(vm, vm),
-        ...providedData
-      })
+      if (originalComponent.data) {
+        const originalDataFn = originalComponent.data
+        objectComponent.data = (vm) => ({
+          ...originalDataFn.call(vm, vm),
+          ...providedData
+        })
+      } else if (objectComponent.setup) {
+        const originalSetupFn = objectComponent.setup
+        objectComponent.setup = function (a, b) {
+          const data = originalSetupFn(a, b)
+          Object.assign(data, providedData)
+          return data
+        }
+      } else {
+        objectComponent.data = () => ({ ...providedData })
+      }
     } else {
       throw new Error(
         'data() option is not supported on functional and class components'

--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -11,7 +11,6 @@ import {
   DefineComponent,
   transformVNodeArgs
 } from 'vue'
-import reactivity from '@vue/reactivity'
 
 import { MountingOptions, Slot } from './types'
 import {
@@ -21,7 +20,6 @@ import {
   isObject,
   isObjectComponent,
   isScriptSetup,
-  mergeDeep,
   mergeGlobalProperties
 } from './utils'
 import { processSlot } from './utils/compileSlots'

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -1,5 +1,4 @@
-import { nextTick, App, ComponentPublicInstance, VNode } from 'vue'
-import * as reactivity from '@vue/reactivity'
+import { nextTick, App, ComponentPublicInstance, VNode, proxyRefs } from 'vue'
 
 import { config } from './config'
 import domEvents from './constants/dom-events'
@@ -266,7 +265,7 @@ export class VueWrapper<
     } else if (!Object.isFrozen(this.componentVM.$.setupState)) {
       // data from setup() function when using the object api
       // @ts-ignore
-      mergeDeep(reactivity.proxyRefs(this.componentVM.$.setupState), data)
+      mergeDeep(proxyRefs(this.componentVM.$.setupState), data)
     } else {
       // data when using data: {...} in the object api
       mergeDeep(this.componentVM.$data, data)

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -1,6 +1,6 @@
 import { nextTick, App, ComponentPublicInstance, VNode } from 'vue'
 import { EMPTY_OBJ as VUE_UNWRITABLE_PLACEHOLDER_OBJECT } from '@vue/shared'
-import reactivity from '@vue/reactivity'
+import * as reactivity from '@vue/reactivity'
 
 import { config } from './config'
 import domEvents from './constants/dom-events'

--- a/tests/setData.spec.ts
+++ b/tests/setData.spec.ts
@@ -308,4 +308,30 @@ describe('setData', () => {
 
     expect(wrapper.find('#show').exists()).toBe(true)
   })
+
+  it('correctly sets initial array refs data when using <script setup>', async () => {
+    const Component = {
+      template: `<div><div v-for="item in items" :key="item">{{ item }}</div></div>`,
+      setup() {
+        const items = ref([])
+        return { items }
+      }
+    }
+
+    const wrapper = shallowMount(Component, {
+      data() {
+        return {
+          items: ['item1', 'item2']
+        }
+      }
+    })
+
+    expect(wrapper.html()).toContain('item1')
+    expect(wrapper.html()).toContain('item2')
+
+    await wrapper.setData({ items: ['item3', 'item4'] })
+
+    expect(wrapper.html()).toContain('item3')
+    expect(wrapper.html()).toContain('item4')
+  })
 })

--- a/tests/setData.spec.ts
+++ b/tests/setData.spec.ts
@@ -284,7 +284,7 @@ describe('setData', () => {
     expect(wrapper.html()).toContain('updated value')
   })
 
-  it('updates data on an scf using <script setup>', async () => {
+  it('updates data on a component using <script setup>', async () => {
     const wrapper = shallowMount(ScriptSetup)
     await wrapper.setData({ count: 20 })
     expect(wrapper.html()).toContain('20')


### PR DESCRIPTION
This PR adds support for `setData()` and `shallowMount({initialData: ...})` for components defined using the `<script setup>` syntax. 

To my surprise this isn't supported yet, yet it seems like an important tool, especially when refactoring components from the Options API to the Composition API.

E.g. the following test would fail:

#### ScriptSetup.vue
```vue [ScriptSetup.vue]
<script setup lang="ts">
import { ref } from 'vue'
const count = ref(0)
const inc = () => { count.value++ }
</script>

<template>
  <button @click="inc()">{{ count }}</button>
</template>
```

#### ScriptSetup.spec.ts
```ts
it('updates data on a component using <script setup>', async () => {
	const wrapper = shallowMount(ScriptSetup)
	await wrapper.setData({ count: 20 })
	expect(wrapper.html()).toContain('20')
})
```



I've added a few tests to the existing setData suite, and everything seems to work as expected.

> [!NOTE]
> All variables from a `<script setup>` / the component's `setup()` function seem to be placed in a single proxy/object by the Vue compiler/runtime.  
>
> This means setData() can technically be used to overwrite everything defined or imported in the setup script/function, not just the `ref`s and `reactive`s.
> I don't think there is an easy way to decide what should and should not be allowed to be overwritten, so for now allow everything.
