### PR TITLE
feat: allow setValue to set values to contenteditable divs

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -136,6 +136,14 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
       this.trigger('input')
       // trigger `change` for `v-model.lazy`
       return this.trigger('change')
+    } else if (tagName === 'DIV' && this.attributes().contenteditable) {
+      // for contenteditable elements, we set the innerHTML
+      // and trigger input and change events
+      // the value will be coerced to a string
+      // and object types will be stringified (either default [object Object] or custom toString)])
+      element.innerHTML = value
+      this.trigger('input')
+      return this.trigger('change')
     } else {
       throw Error(`wrapper.setValue() cannot be called on ${tagName}`)
     }

--- a/tests/setValue.spec.ts
+++ b/tests/setValue.spec.ts
@@ -343,4 +343,25 @@ describe('setValue', () => {
       })
     })
   })
+
+  describe('on contenteditable elements', () => {
+    it('sets element innerHTML', async () => {
+      const richContent = '<h1>Rich title</h1><p>Rich description</p>'
+      const onInput = vi.fn()
+      const onChange = vi.fn()
+      const Comp = defineComponent({
+        setup() {
+          return () => h('div', { contenteditable: 'true', onInput, onChange })
+        }
+      })
+
+      const wrapper = mount(Comp)
+      const editable = wrapper.find<HTMLDivElement>('div')
+      await editable.setValue(richContent)
+
+      expect(editable.element.innerHTML).toBe(richContent)
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+  })
 })


### PR DESCRIPTION
Implements https://github.com/vuejs/test-utils/issues/2390

## Support `setValue` for `contenteditable` Elements

### Summary

This PR extends the `DOMWrapper.setValue` method to support elements with the `contenteditable` attribute (such as `<div contenteditable="true">`). Previously, `setValue` was only applicable to form inputs, textareas, and selects. With this change, users can now easily set the inner HTML of contenteditable elements in their tests, and trigger the expected `input` and `change` events.

### Details

- **New logic in `setValue`:**  
  When called on a `DIV` with the `contenteditable` attribute, `setValue` updates the element’s `innerHTML`, triggers both `input` and `change` events, and supports any value (object values will be stringified).
- **Error handling:**  
  If `setValue` is called on an unsupported element, an error is still thrown as before.
- **Tests:**  
  Added a dedicated test case to verify that `setValue` properly updates a contenteditable element’s inner HTML and triggers the appropriate events.

### Motivation

Rich text editors and other contenteditable-based components are common in modern web apps. This enhancement allows for more robust and expressive testing of these components, improving DX and test reliability.

### Example Usage

```js
const wrapper = mount(Comp)
const editable = wrapper.find('div[contenteditable]')
await editable.setValue('<b>Bold</b>')
expect(editable.element.innerHTML).toBe('<b>Bold</b>')
```