### PR TITLE
fix: remove duplicate code from asserting the emitted events section …

### DIFF
--- a/docs/guide/essentials/event-handling.md
+++ b/docs/guide/essentials/event-handling.md
@@ -38,7 +38,6 @@ test('emits an event when clicked', () => {
   const wrapper = mount(Counter)
 
   wrapper.find('button').trigger('click')
-  wrapper.find('button').trigger('click')
 
   expect(wrapper.emitted()).toHaveProperty('increment')
 })


### PR DESCRIPTION
…of event handeling

In the Asserting the emitted events section, the code example, there is duplicate code like,

```js 
wrapper.find('button').trigger('click')

```
That code appears twice. I removed the unused code.