### PR TITLE
fix: remove wrapper div when unmount

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -99,6 +99,9 @@ export function mount(
     }
 
     to.appendChild(el)
+    app.onUnmount(() => {
+      to?.removeChild(el)
+    })
   }
   const vm = app.mount(el)
   if (errorsOnMount.length) {

--- a/tests/mount.spec.ts
+++ b/tests/mount.spec.ts
@@ -102,4 +102,14 @@ describe('mount: general tests', () => {
     })
     expect(wrapper.text()).toContain('Hello world')
   })
+
+  it('should remove wrapper div when unmount', () => {
+    expect(document.body.firstChild, 'Container should be empty').toBeNull();
+
+    const wrapper = mount(Hello, { props: { msg: 'Hello world' }, attachTo: document.body });
+    expect(document.body.firstChild, 'Container should have mounted component wrapper').toBeInstanceOf(HTMLDivElement);
+    
+    wrapper.unmount();
+    expect(document.body.firstChild, 'Container should be empty').toBeNull();
+  })
 })

--- a/tests/mount.spec.ts
+++ b/tests/mount.spec.ts
@@ -104,12 +104,18 @@ describe('mount: general tests', () => {
   })
 
   it('should remove wrapper div when unmount', () => {
-    expect(document.body.firstChild, 'Container should be empty').toBeNull();
+    expect(document.body.firstChild, 'Container should be empty').toBeNull()
 
-    const wrapper = mount(Hello, { props: { msg: 'Hello world' }, attachTo: document.body });
-    expect(document.body.firstChild, 'Container should have mounted component wrapper').toBeInstanceOf(HTMLDivElement);
-    
-    wrapper.unmount();
-    expect(document.body.firstChild, 'Container should be empty').toBeNull();
+    const wrapper = mount(Hello, {
+      props: { msg: 'Hello world' },
+      attachTo: document.body
+    })
+    expect(
+      document.body.firstChild,
+      'Container should have mounted component wrapper'
+    ).toBeInstanceOf(HTMLDivElement)
+
+    wrapper.unmount()
+    expect(document.body.firstChild, 'Container should be empty').toBeNull()
   })
 })


### PR DESCRIPTION
Fix #2690 
Regist a `onUnmount` to remove the wapper when append the wapper `div` to target DOM.