### PR TITLE
fix: make mount options slots compatible with noUncheckedIndexedAccess true

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -24,7 +24,7 @@ export type ComponentMountingOptions<
   P extends ComponentProps<T> = ComponentProps<T>
 > = Omit<MountingOptions<P, ComponentData<T>>, 'slots'> & {
   slots?: {
-    [K in keyof ComponentSlots<T>]: WithArray<
+    [K in keyof ComponentSlots<T>]?: WithArray<
       | ShimSlotReturnType<ComponentSlots<T>[K]>
       | string
       | VNode


### PR DESCRIPTION
It's not necessary to define all slots, pratially defined slots are used all over the place throughout the tests here and routinely by users. However, the type for slots in mount options was not partiall and that caused type errors for people using `noUncheckedIndexedAccess: true` even though it work fine in runtime. Adding `?` doesn't change anything for users with `noUncheckedIndexedAccess: false`, it has passed type checking before and will continue to pass. Type checking will now also pass for users with partially defined slots using `noUncheckedIndexedAccess: true`.
