### PR TITLE
docs: add note about mocking `requestAnimationFrame` for transitions

### DIFF
--- a/docs/guide/advanced/transitions.md
+++ b/docs/guide/advanced/transitions.md
@@ -66,3 +66,9 @@ Potential solutions:
 - You can create your own transition stub that can handle these hooks if necessary.
 - You can spy the warning in the test to silence it.
 :::
+
+If you do turn off auto stubbing, note that you might also need to mock `requestAnimationFrame` to ensure that the javascript hooks fire properly:
+
+```js
+vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+```


### PR DESCRIPTION
I've gotten tripped up by this a few times now so I think it would be good to mention - there is probably more documentation to add at some point but this is a good start 🙂

I know that both `vitest` and `jest` have some fake timer code related to this which might be better in some cases, but as far as I know it doesn't "just work" and does require using fake timers so I think it's still useful to document how you can manually mock it.

I'm happy to expand the documentation to also mention this once I've had a chance to explore it myself, but I'm currently not able to as it was introduced in Jest v30 and I'm stuck on v29 due to https://github.com/vuejs/vue-jest/pull/573 🙃

Somewhat related to https://github.com/vuejs/test-utils/discussions/1913