### PR TITLE
chore: add explicit coverage include for vitest v4

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,6 +27,9 @@ export default defineConfig({
     pool: 'threads',
     setupFiles: [path.resolve(__dirname, './setup.js')],
     include: ['tests/**/*.spec.ts'],
+    coverage: {
+      include: ['src/**']
+    },
     server: {
       deps: {
         inline: ['vue', '@vue/compat']


### PR DESCRIPTION
The migration guide recommends this: https://vitest.dev/guide/migration.html#vitest-4