### PR TITLE
feat: enforce consistent usage of type imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,11 @@
+import { defineConfig, globalIgnores } from 'eslint/config'
 import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import prettierPluginRecommended from 'eslint-plugin-prettier/recommended'
 
-export default [
+export default defineConfig(
+  globalIgnores(['docs/.vitepress', 'coverage', 'dist']),
   {
-    ignores: ['docs/.vitepress', 'coverage', 'dist']
-  },
-  ...tseslint.config({
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,
@@ -14,17 +13,14 @@ export default [
     ],
     rules: {
       'prettier/prettier': ['error'],
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: ['src/*']
-        }
-      ],
+      'no-restricted-imports': ['error', { patterns: ['src/*'] }],
+
+      '@typescript-eslint/consistent-type-imports': 'error',
 
       // Currently, disabled to avoid a lot of changes during migration
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/ban-ts-comment': 'off'
     }
-  })
-]
+  }
+)

--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -1,20 +1,20 @@
-import { VNode } from 'vue'
+import type { VNode } from 'vue'
 import { textContent } from './utils'
 import type { TriggerOptions } from './createDomEvent'
-import {
+import type {
   ComponentInternalInstance,
   ComponentOptions,
   ComponentPublicInstance,
   ComputedOptions,
   CreateComponentPublicInstance,
   FunctionalComponent,
-  MethodOptions,
-  nextTick
+  MethodOptions
 } from 'vue'
+import { nextTick } from 'vue'
 import { createDOMEvent } from './createDomEvent'
-import { DomEventNameWithModifier } from './constants/dom-events'
+import type { DomEventNameWithModifier } from './constants/dom-events'
 import type { VueWrapper } from './vueWrapper'
-import {
+import type {
   DefinedComponent,
   FindAllComponentsSelector,
   FindComponentSelector,
@@ -22,7 +22,7 @@ import {
   RefSelector,
   VueNode
 } from './types'
-import WrapperLike from './interfaces/wrapperLike'
+import type WrapperLike from './interfaces/wrapperLike'
 import { find, matches } from './utils/find'
 import { createWrapperError } from './errorWrapper'
 import { isElementVisible } from './utils/isElementVisible'
@@ -30,7 +30,8 @@ import { isElement } from './utils/isElement'
 import type { DOMWrapper } from './domWrapper'
 import { createDOMWrapper, createVueWrapper } from './wrapperFactory'
 import { stringifyNode } from './utils/stringifyNode'
-import beautify, { HTMLBeautifyOptions } from 'js-beautify'
+import type { HTMLBeautifyOptions } from 'js-beautify'
+import beautify from 'js-beautify'
 
 export default abstract class BaseWrapper<ElementType extends Node>
   implements WrapperLike

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
-import { GlobalMountOptions, Stub } from './types'
-import { VueWrapper } from './vueWrapper'
-import { DOMWrapper } from './domWrapper'
-import { CustomCreateStub } from './vnodeTransformers/stubComponentsTransformer'
+import type { GlobalMountOptions, Stub } from './types'
+import type { VueWrapper } from './vueWrapper'
+import type { DOMWrapper } from './domWrapper'
+import type { CustomCreateStub } from './vnodeTransformers/stubComponentsTransformer'
 
 export interface GlobalConfigOptions {
   global: Required<Omit<GlobalMountOptions, 'stubs'>> & {

--- a/src/createDomEvent.ts
+++ b/src/createDomEvent.ts
@@ -1,9 +1,11 @@
-import domEvents, {
+import type {
   DomEvent,
   DomEventName,
   DomEventNameWithModifier,
+  Modifier
+} from './constants/dom-events'
+import domEvents, {
   KeyName,
-  Modifier,
   ignorableKeyModifiers,
   systemKeyModifiers,
   mouseKeyModifiers,

--- a/src/createInstance.ts
+++ b/src/createInstance.ts
@@ -1,3 +1,9 @@
+import type {
+  AppConfig,
+  ComponentOptions,
+  ConcreteComponent,
+  DefineComponent
+} from 'vue'
 import {
   h,
   createApp,
@@ -5,15 +11,11 @@ import {
   reactive,
   shallowReactive,
   ref,
-  AppConfig,
-  ComponentOptions,
-  ConcreteComponent,
-  DefineComponent,
   transformVNodeArgs,
   proxyRefs
 } from 'vue'
 
-import { MountingOptions, Slot } from './types'
+import type { MountingOptions, Slot } from './types'
 import {
   getComponentsFromStubs,
   getDirectivesFromStubs,
@@ -32,10 +34,8 @@ import {
   unwrapLegacyVueExtendComponent
 } from './utils/vueCompatSupport'
 import { createVNodeTransformer } from './vnodeTransformers/util'
-import {
-  createStubComponentsTransformer,
-  CreateStubComponentsTransformerConfig
-} from './vnodeTransformers/stubComponentsTransformer'
+import type { CreateStubComponentsTransformerConfig } from './vnodeTransformers/stubComponentsTransformer'
+import { createStubComponentsTransformer } from './vnodeTransformers/stubComponentsTransformer'
 import { createStubDirectivesTransformer } from './vnodeTransformers/stubDirectivesTransformer'
 import { isDeepRef } from './utils/isDeepRef'
 

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -1,13 +1,13 @@
-import { VNode } from 'vue'
+import type { VNode } from 'vue'
 import { config } from './config'
 import BaseWrapper from './baseWrapper'
-import WrapperLike from './interfaces/wrapperLike'
+import type WrapperLike from './interfaces/wrapperLike'
 import {
   createDOMWrapper,
   registerFactory,
   WrapperType
 } from './wrapperFactory'
-import { RefSelector } from './types'
+import type { RefSelector } from './types'
 import { isRefSelector } from './utils'
 import { createWrapperError } from './errorWrapper'
 

--- a/src/emit.ts
+++ b/src/emit.ts
@@ -1,9 +1,9 @@
-import {
-  setDevtoolsHook,
+import type {
   devtools,
   ComponentPublicInstance,
   ComponentInternalInstance
 } from 'vue'
+import { setDevtoolsHook } from 'vue'
 import { getGlobalThis } from './utils'
 
 type Events<T = unknown> = Record<number, Record<string, T[]>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,13 @@ import { VueWrapper } from './vueWrapper'
 import BaseWrapper from './baseWrapper'
 import { mount, shallowMount } from './mount'
 import { renderToString } from './renderToString'
-import { MountingOptions, Stubs } from './types'
+import type { MountingOptions, Stubs } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { createWrapperError } from './errorWrapper'
 import { config } from './config'
 import { flushPromises } from './utils/flushPromises'
 import { enableAutoUnmount, disableAutoUnmount } from './utils/autoUnmount'
+import type { ComponentMountingOptions } from './mount'
 
 export {
   mount,
@@ -22,9 +23,7 @@ export {
   BaseWrapper,
   config,
   flushPromises,
-  MountingOptions,
-  Stubs,
   createWrapperError
 }
 
-export type { ComponentMountingOptions } from './mount'
+export type { MountingOptions, Stubs, ComponentMountingOptions }

--- a/src/interfaces/wrapperLike.ts
+++ b/src/interfaces/wrapperLike.ts
@@ -1,14 +1,14 @@
-import { DomEventNameWithModifier } from '../constants/dom-events'
-import { TriggerOptions } from '../createDomEvent'
-import {
+import type { DomEventNameWithModifier } from '../constants/dom-events'
+import type { TriggerOptions } from '../createDomEvent'
+import type {
   DefinedComponent,
   FindAllComponentsSelector,
   FindComponentSelector,
   NameSelector,
   RefSelector
 } from '../types'
-import { VueWrapper } from '../vueWrapper'
-import { ComponentPublicInstance, FunctionalComponent } from 'vue'
+import type { VueWrapper } from '../vueWrapper'
+import type { ComponentPublicInstance, FunctionalComponent } from 'vue'
 import type { DOMWrapper } from '../domWrapper'
 
 export default interface WrapperLike {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,13 +1,13 @@
-import { ComponentPublicInstance, DefineComponent, VNode } from 'vue'
+import type { ComponentPublicInstance, DefineComponent, VNode } from 'vue'
 import type {
   ComponentExposed,
   ComponentProps,
   ComponentSlots
 } from 'vue-component-type-helpers'
 import { createInstance } from './createInstance'
-import { MountingOptions } from './types'
+import type { MountingOptions } from './types'
 import { trackInstance } from './utils/autoUnmount'
-import { VueWrapper } from './vueWrapper'
+import type { VueWrapper } from './vueWrapper'
 import { createVueWrapper } from './wrapperFactory'
 
 type ShimSlotReturnType<T> = T extends (...args: infer P) => any

--- a/src/renderToString.ts
+++ b/src/renderToString.ts
@@ -1,8 +1,8 @@
 import { renderToString as baseRenderToString } from '@vue/server-renderer'
-import { DefineComponent } from 'vue'
+import type { DefineComponent } from 'vue'
 import { createInstance } from './createInstance'
-import { ComponentMountingOptions } from './mount'
-import { RenderMountingOptions } from './types'
+import type { ComponentMountingOptions } from './mount'
+import type { RenderMountingOptions } from './types'
 
 export function renderToString<
   T,

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,4 +1,4 @@
-import { Component } from 'vue'
+import type { Component } from 'vue'
 
 // Stubbing occurs when in vnode transformer we're swapping
 // component vnode type due to stubbing either component

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-object-type */
-import {
+import type {
   Component,
   ComponentOptions,
   Directive,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import { GlobalMountOptions, RefSelector, Stub, Stubs } from './types'
-import {
+import type { GlobalMountOptions, RefSelector, Stub, Stubs } from './types'
+import type {
   Component,
   ComponentOptions,
   ComponentPublicInstance,

--- a/src/utils/autoUnmount.ts
+++ b/src/utils/autoUnmount.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import type { VueWrapper } from '../vueWrapper'
 
 let isEnabled = false

--- a/src/utils/componentName.ts
+++ b/src/utils/componentName.ts
@@ -1,4 +1,4 @@
-import { ComponentInternalInstance, VNodeTypes } from 'vue'
+import type { ComponentInternalInstance, VNodeTypes } from 'vue'
 import { isFunctionalComponent, isObjectComponent } from '../utils'
 import {
   isLegacyExtendedComponent,

--- a/src/utils/find.ts
+++ b/src/utils/find.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ComponentInternalInstance,
   VNode,
   VNodeChild,
@@ -7,7 +7,7 @@ import {
   VNodeTypes
 } from 'vue'
 import { getOriginalComponentFromStub } from '../stubs'
-import { FindAllComponentsSelector } from '../types'
+import type { FindAllComponentsSelector } from '../types'
 import { isComponent } from '../utils'
 import { matchName } from './matchName'
 import { unwrapLegacyVueExtendComponent } from './vueCompatSupport'

--- a/src/utils/getRootNodes.ts
+++ b/src/utils/getRootNodes.ts
@@ -1,5 +1,5 @@
 import { isNotNullOrUndefined } from '../utils'
-import { VNode, VNodeArrayChildren } from 'vue'
+import type { VNode, VNodeArrayChildren } from 'vue'
 import { ShapeFlags } from './vueShared'
 
 export function getRootNodes(vnode: VNode): Node[] {

--- a/src/vnodeTransformers/stubComponentsTransformer.ts
+++ b/src/vnodeTransformers/stubComponentsTransformer.ts
@@ -1,23 +1,21 @@
-import {
-  isKeepAlive,
-  isRootComponent,
-  isTeleport,
-  VTUVNodeTypeTransformer
-} from './util'
-import {
-  Transition,
-  TransitionGroup,
-  BaseTransition,
+import type { VTUVNodeTypeTransformer } from './util'
+import { isKeepAlive, isRootComponent, isTeleport } from './util'
+import type {
   Teleport,
   KeepAlive,
-  h,
-  defineComponent,
   VNodeTypes,
   ConcreteComponent,
   ComponentPropsOptions,
   ComponentObjectPropsOptions,
   Component,
   ComponentOptions
+} from 'vue'
+import {
+  Transition,
+  TransitionGroup,
+  BaseTransition,
+  h,
+  defineComponent
 } from 'vue'
 import { hyphenate } from '../utils/vueShared'
 import { matchName } from '../utils/matchName'

--- a/src/vnodeTransformers/stubDirectivesTransformer.ts
+++ b/src/vnodeTransformers/stubDirectivesTransformer.ts
@@ -1,4 +1,4 @@
-import { Directive } from 'vue'
+import type { Directive } from 'vue'
 import { isObjectComponent } from '../utils'
 import type { VTUVNodeTypeTransformer } from './util'
 

--- a/src/vnodeTransformers/util.ts
+++ b/src/vnodeTransformers/util.ts
@@ -1,6 +1,6 @@
 import { isComponent } from '../utils'
 import { registerStub } from '../stubs'
-import { Component, ConcreteComponent, transformVNodeArgs } from 'vue'
+import type { Component, ConcreteComponent, transformVNodeArgs } from 'vue'
 
 type VNodeArgsTransformerFn = NonNullable<
   Parameters<typeof transformVNodeArgs>[0]

--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -1,8 +1,9 @@
-import { nextTick, App, ComponentPublicInstance, VNode, proxyRefs } from 'vue'
+import type { App, ComponentPublicInstance, VNode } from 'vue'
+import { nextTick, proxyRefs } from 'vue'
 
 import { config } from './config'
 import domEvents from './constants/dom-events'
-import { VueElement, VueNode } from './types'
+import type { VueElement, VueNode } from './types'
 import { hasSetupState, mergeDeep } from './utils'
 import { getRootNodes } from './utils/getRootNodes'
 import { emitted, recordEvent, removeEventHistory } from './emit'

--- a/src/wrapperFactory.ts
+++ b/src/wrapperFactory.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance, App, VNode } from 'vue'
+import type { ComponentPublicInstance, App, VNode } from 'vue'
 import type { DOMWrapper as DOMWrapperType } from './domWrapper'
 import type { VueWrapper as VueWrapperType } from './vueWrapper'
 

--- a/test-dts/findComponent.d-test.ts
+++ b/test-dts/findComponent.d-test.ts
@@ -1,7 +1,8 @@
 import { expectType } from './index'
 import { defineComponent } from 'vue'
-import { DOMWrapper, mount, VueWrapper } from '../src'
-import WrapperLike from '../src/interfaces/wrapperLike'
+import type { DOMWrapper, VueWrapper } from '../src'
+import { mount } from '../src'
+import type WrapperLike from '../src/interfaces/wrapperLike'
 
 const FuncComponent = () => 'hello'
 

--- a/test-dts/getComponent.d-test.ts
+++ b/test-dts/getComponent.d-test.ts
@@ -1,7 +1,8 @@
 import { expectType } from './index'
-import { defineComponent, ComponentPublicInstance } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
+import { defineComponent } from 'vue'
 import { mount } from '../src'
-import WrapperLike from '../src/interfaces/wrapperLike'
+import type WrapperLike from '../src/interfaces/wrapperLike'
 
 const ComponentToFind = defineComponent({
   props: {

--- a/test-dts/mount.d-test.ts
+++ b/test-dts/mount.d-test.ts
@@ -1,17 +1,19 @@
 import { expectError, expectType } from './index'
-import {
+import type {
   ComponentOptions,
   DefineComponent,
-  defineComponent,
-  FunctionalComponent,
-  getCurrentInstance,
-  h,
-  ref,
   SetupContext,
   Prop,
   VNodeChild,
   SlotsType,
   VNode
+} from 'vue'
+import {
+  defineComponent,
+  FunctionalComponent,
+  getCurrentInstance,
+  h,
+  ref
 } from 'vue'
 import { Options, Vue } from 'vue-class-component'
 import { mount } from '../src'

--- a/test-dts/plugins.d-test.ts
+++ b/test-dts/plugins.d-test.ts
@@ -1,6 +1,7 @@
 import { expectError } from './index'
-import { ComponentPublicInstance } from 'vue'
-import { config, VueWrapper } from '../src'
+import type { ComponentPublicInstance } from 'vue'
+import type { VueWrapper } from '../src'
+import { config } from '../src'
 
 interface OptionsI {
   msg: string

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { defineComponent, ComponentPublicInstance, h, inject } from 'vue'
-import type { App, ComponentCustomProperties } from 'vue'
+import { defineComponent, h, inject } from 'vue'
+import type {
+  App,
+  ComponentCustomProperties,
+  ComponentPublicInstance
+} from 'vue'
 import { config, mount } from '../src'
 import Hello from './components/Hello.vue'
 import ComponentWithSlots from './components/ComponentWithSlots.vue'
-import { Router } from 'vue-router'
+import type { Router } from 'vue-router'
 
 describe('config', () => {
   beforeEach(() => {

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import {
-  defineComponent,
-  FunctionalComponent,
-  getCurrentInstance,
-  h,
-  SetupContext
-} from 'vue'
+import type { FunctionalComponent, SetupContext } from 'vue'
+import { defineComponent, getCurrentInstance, h } from 'vue'
 import { Vue } from 'vue-class-component'
 import EmitsEventSFC from './components/EmitsEventSFC.vue'
 import EmitsEventScriptSetup from './components/EmitsEventScriptSetup.vue'

--- a/tests/features/async-components.spec.ts
+++ b/tests/features/async-components.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
-import { defineAsyncComponent, defineComponent, h, AppConfig } from 'vue'
+import type { AppConfig } from 'vue'
+import { defineAsyncComponent, defineComponent, h } from 'vue'
 import { mount, shallowMount, flushPromises } from '../../src'
 import Hello from '../components/Hello.vue'
 

--- a/tests/features/plugins.spec.ts
+++ b/tests/features/plugins.spec.ts
@@ -7,8 +7,10 @@ import {
   it,
   vi
 } from 'vitest'
-import { ComponentPublicInstance, h } from 'vue'
-import { mount, config, VueWrapper } from '../../src'
+import type { ComponentPublicInstance } from 'vue'
+import { h } from 'vue'
+import type { VueWrapper } from '../../src'
+import { mount, config } from '../../src'
 
 declare module '../../src/vueWrapper' {
   interface VueWrapper {

--- a/tests/find.spec.ts
+++ b/tests/find.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, Fragment } from 'vue'
-import { mount, VueWrapper } from '../src'
+import type { VueWrapper } from '../src'
+import { mount } from '../src'
 import SuspenseComponent from './components/Suspense.vue'
 import ParentComponent from './components/ParentComponent.vue'
 import MultipleRootRender from './components/MultipleRootRender.vue'

--- a/tests/findAllComponents.spec.ts
+++ b/tests/findAllComponents.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mount } from '../src'
 import Hello from './components/Hello.vue'
-import { DefineComponent, defineComponent, h } from 'vue'
+import type { DefineComponent } from 'vue'
+import { defineComponent, h } from 'vue'
 
 const compC = defineComponent({
   name: 'ComponentC',

--- a/tests/functionalComponents.spec.ts
+++ b/tests/functionalComponents.spec.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { DOMWrapper, mount, VueWrapper } from '../src'
-import { h, Slots } from 'vue'
+import type { VueWrapper } from '../src'
+import { DOMWrapper, mount } from '../src'
+import type { Slots } from 'vue'
+import { h } from 'vue'
 import Hello from './components/Hello.vue'
 
 describe('functionalComponents', () => {

--- a/tests/mountingOptions/global.directives.spec.ts
+++ b/tests/mountingOptions/global.directives.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { Directive } from 'vue'
+import type { Directive } from 'vue'
 import { mount } from '../../src'
 
 const MyDirective: Directive = {

--- a/tests/mountingOptions/global.plugins.spec.ts
+++ b/tests/mountingOptions/global.plugins.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, it, vi } from 'vitest'
-import { h, App } from 'vue'
+import type { App } from 'vue'
+import { h } from 'vue'
 
 import { mount } from '../../src'
 import ScriptSetup from '../components/ScriptSetup.vue'

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { h, defineComponent, defineAsyncComponent, Directive } from 'vue'
+import type { Directive } from 'vue'
+import { h, defineComponent, defineAsyncComponent } from 'vue'
 import { config, flushPromises, mount, RouterLinkStub } from '../../src'
 import Hello from '../components/Hello.vue'
 import ComponentWithoutName from '../components/ComponentWithoutName.vue'

--- a/tests/props.spec.ts
+++ b/tests/props.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { mount, shallowMount, VueWrapper } from '../src'
+import type { VueWrapper } from '../src'
+import { mount, shallowMount } from '../src'
 import WithProps from './components/WithProps.vue'
 import PropWithSymbol from './components/PropWithSymbol.vue'
 import Hello from './components/Hello.vue'

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { defineAsyncComponent, defineComponent } from 'vue'
-import { mount, shallowMount, VueWrapper } from '../src'
+import type { VueWrapper } from '../src'
+import { mount, shallowMount } from '../src'
 import ComponentWithChildren from './components/ComponentWithChildren.vue'
 import ScriptSetupWithChildren from './components/ScriptSetupWithChildren.vue'
 import DynamicComponentWithComputedProperty from './components/DynamicComponentWithComputedProperty.vue'

--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, ref } from 'vue'
 
 import { mount } from '../src'
-import { keyCodesByKeyName, KeyName } from '../src/createDomEvent'
+import type { KeyName } from '../src/createDomEvent'
+import { keyCodesByKeyName } from '../src/createDomEvent'
 
 describe('trigger', () => {
   describe('on click', () => {


### PR DESCRIPTION
I noticed that the package was exporting few types as part of a "runtime" export:

https://github.com/vuejs/test-utils/blob/94b2eee1981e6c99fc39df652f78e698ac5f6126/src/index.ts#L13-L28

https://github.com/vuejs/test-utils/blob/94b2eee1981e6c99fc39df652f78e698ac5f6126/src/index.ts#L25-L26

---

https://github.com/vuejs/test-utils/blob/94b2eee1981e6c99fc39df652f78e698ac5f6126/src/types.ts#L89

https://github.com/vuejs/test-utils/blob/94b2eee1981e6c99fc39df652f78e698ac5f6126/src/types.ts#L111

---

This PR enables and fixes all the issues reported by [`consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/)  `typescript-eslint` rule to ensure that `import` / `export` types are marked correctly.

I have also updated the `eslint.config.mjs` to use helpers from `eslint/config` instead of the deprecated `tseslint.config`.