### PR TITLE
fix: correct <summary> element behavior

### DIFF
--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -19,30 +19,35 @@ function isStyleVisible<T extends Element>(element: T) {
   )
 }
 
-function isAttributeVisible<T extends Element>(element: T) {
-  if (element instanceof HTMLInputElement && element.type === 'hidden') {
+/**
+ * checks if an element is visible by checking its attributes and its parents' attributes.
+ * @param element 
+ * @returns boolean
+ */
+function isElementVisibleByAttribute<T extends Element>(element: T) {
+  if (element instanceof HTMLInputElement && (element.type === 'hidden' || element.hidden)) {
     return false
   }
-
-  if (element instanceof HTMLElement && element.hidden) {
-    return false
-  }
-
   return true
 }
 
+/**
+ * checks if an element is hidden by a closed details element.
+ * @param element 
+ * @returns boolean
+ */
 function isHiddenByClosedDetails<T extends Element>(element: T) {
+  const summary = element.closest('summary')
   let parent = element.parentElement
 
   while (parent) {
     if (parent.nodeName === 'DETAILS' && !(parent as HTMLDetailsElement).open) {
-      if (
-        !(element.nodeName === 'SUMMARY' && element.parentElement === parent)
-      ) {
+      // If no <summary> ancestor exists, or the <summary> is not a direct child of this <details>, 
+      // then the content is hidden
+      if (!summary || summary.parentElement !== parent) {
         return true
       }
     }
-
     parent = parent.parentElement
   }
 
@@ -53,7 +58,7 @@ export function isElementVisible<T extends Element>(element: T): boolean {
   return (
     element.nodeName !== '#comment' &&
     isStyleVisible(element) &&
-    isAttributeVisible(element) &&
+    isElementVisibleByAttribute(element) &&
     !isHiddenByClosedDetails(element) &&
     (!element.parentElement || isElementVisible(element.parentElement))
   )

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -20,16 +20,31 @@ function isStyleVisible<T extends Element>(element: T) {
 }
 
 function isAttributeVisible<T extends Element>(element: T) {
-  if (
-    element.nodeName === 'SUMMARY' &&
-    element.closest('details')
-  ) {
-    return true
+  if (element instanceof HTMLInputElement && element.type === 'hidden') {
+    return false
   }
-  return (
-    !element.hasAttribute('hidden') &&
-    (element.nodeName === 'DETAILS' ? element.hasAttribute('open') : true)
-  )
+
+  if (element instanceof HTMLElement && element.hidden) {
+    return false
+  }
+
+  return true
+}
+
+function isHiddenByClosedDetails<T extends Element>(element: T) {
+  let parent = element.parentElement
+
+  while (parent) {
+    if (parent.nodeName === 'DETAILS' && !(parent as HTMLDetailsElement).open) {
+      if (!(element.nodeName === 'SUMMARY' && element.parentElement === parent)) {
+        return true
+      }
+    }
+
+    parent = parent.parentElement
+  }
+
+  return false
 }
 
 export function isElementVisible<T extends Element>(element: T): boolean {
@@ -37,6 +52,7 @@ export function isElementVisible<T extends Element>(element: T): boolean {
     element.nodeName !== '#comment' &&
     isStyleVisible(element) &&
     isAttributeVisible(element) &&
-    (element.nodeName === 'SUMMARY' || !element.parentElement || isElementVisible(element.parentElement))
+    !isHiddenByClosedDetails(element) &&
+    (!element.parentElement || isElementVisible(element.parentElement))
   )
 }

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -20,6 +20,12 @@ function isStyleVisible<T extends Element>(element: T) {
 }
 
 function isAttributeVisible<T extends Element>(element: T) {
+  if (
+    element.nodeName === 'SUMMARY' &&
+    element.closest('details')
+  ) {
+    return true
+  }
   return (
     !element.hasAttribute('hidden') &&
     (element.nodeName === 'DETAILS' ? element.hasAttribute('open') : true)
@@ -31,6 +37,6 @@ export function isElementVisible<T extends Element>(element: T): boolean {
     element.nodeName !== '#comment' &&
     isStyleVisible(element) &&
     isAttributeVisible(element) &&
-    (!element.parentElement || isElementVisible(element.parentElement))
+    (element.nodeName === 'SUMMARY' || !element.parentElement || isElementVisible(element.parentElement))
   )
 }

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -36,7 +36,9 @@ function isHiddenByClosedDetails<T extends Element>(element: T) {
 
   while (parent) {
     if (parent.nodeName === 'DETAILS' && !(parent as HTMLDetailsElement).open) {
-      if (!(element.nodeName === 'SUMMARY' && element.parentElement === parent)) {
+      if (
+        !(element.nodeName === 'SUMMARY' && element.parentElement === parent)
+      ) {
         return true
       }
     }

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -21,7 +21,7 @@ function isStyleVisible<T extends Element>(element: T) {
 
 /**
  * checks if an element is visible by checking its hidden attribute and parent visibility.
- * @param element 
+ * @param element
  * @returns boolean
  */
 function isElementVisibleByAttribute<T extends Element>(element: T) {
@@ -34,7 +34,7 @@ function isElementVisibleByAttribute<T extends Element>(element: T) {
 
 /**
  * checks if an element is hidden by a closed details element.
- * @param element 
+ * @param element
  * @returns boolean
  */
 function isHiddenByClosedDetails<T extends Element>(element: T) {
@@ -43,7 +43,7 @@ function isHiddenByClosedDetails<T extends Element>(element: T) {
 
   while (parent) {
     if (parent.nodeName === 'DETAILS' && !(parent as HTMLDetailsElement).open) {
-      // If no <summary> ancestor exists, or the <summary> is not a direct child of this <details>, 
+      // If no <summary> ancestor exists, or the <summary> is not a direct child of this <details>,
       // then the content is hidden
       if (!summary || summary.parentElement !== parent) {
         return true

--- a/src/utils/isElementVisible.ts
+++ b/src/utils/isElementVisible.ts
@@ -20,14 +20,15 @@ function isStyleVisible<T extends Element>(element: T) {
 }
 
 /**
- * checks if an element is visible by checking its attributes and its parents' attributes.
+ * checks if an element is visible by checking its hidden attribute and parent visibility.
  * @param element 
  * @returns boolean
  */
 function isElementVisibleByAttribute<T extends Element>(element: T) {
-  if (element instanceof HTMLInputElement && (element.type === 'hidden' || element.hidden)) {
+  if (element instanceof HTMLElement && element.hidden) {
     return false
   }
+
   return true
 }
 

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -228,6 +228,16 @@ describe('isVisible', () => {
         })
         expect(wrapper.isVisible()).toBe(false)
       })
+      it ('DetailContent should be visible when summary is visible', () => {
+        const DetailContent = defineComponent({
+          template: `<details><summary>Summary</summary><div>Content</div></details>`
+        })
+
+        const wrapper = mount(DetailContent)
+        expect(wrapper.find('summary').isVisible()).toBe(true)
+        expect(wrapper.find('div').isVisible()).toBe(false)
+
+      })
     })
   })
 })

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -228,6 +228,31 @@ describe('isVisible', () => {
         })
         expect(wrapper.isVisible()).toBe(false)
       })
+    })
+
+    describe('details and summary elements', () => {
+      it('DetailContent should be invisible when display:none is applied by class', () => {
+        const style = document.createElement('style')
+        document.head.appendChild(style)
+        style.sheet!.insertRule('.hidden { display: none; }')
+
+        const wrapper = mount({
+          template: '<div id="my-div" class="hidden"><details><summary>Summary</summary></details></div>'
+        })
+
+        expect(wrapper.get('#my-div').isVisible()).toBe(false)
+        expect(wrapper.find('summary').isVisible()).toBe(false)
+        expect(wrapper.find('details').isVisible()).toBe(false)
+      })
+      it('DetailContent should be invisible when display:none is applied by style attribute', () => {
+        const wrapper = mount({
+          template: '<div id="my-div" style="display: none;"><details><summary>Summary</summary></details></div>'
+        })
+
+        expect(wrapper.get('#my-div').isVisible()).toBe(false)
+        expect(wrapper.find('summary').isVisible()).toBe(false)
+        expect(wrapper.find('details').isVisible()).toBe(false)
+      })
       it('DetailContent should be visible when summary is visible', () => {
         const DetailContent = defineComponent({
           template: `<details><summary>Summary</summary><div>Content</div></details>`
@@ -238,19 +263,12 @@ describe('isVisible', () => {
         expect(wrapper.find('summary').isVisible()).toBe(true)
         expect(wrapper.find('div').isVisible()).toBe(false)
       })
-      it('should consider a summary as hidden when an ancestor is hidden', () => {
-        const HiddenAncestorSummary = defineComponent({
-          template: `
-            <div style="display: none;">
-              <details>
-                <summary>Summary</summary>
-              </details>
-            </div>
-          `
+      it ('DetailContent shouild be visible when summarys child is visible', () => {
+        const childContent = defineComponent({
+          template: `<details><summary><span>Summary</span></summary></details>`
         })
-
-        const wrapper = mount(HiddenAncestorSummary)
-        expect(wrapper.find('summary').isVisible()).toBe(false)
+        const wrapper = mount(childContent)
+        expect(wrapper.find('summary span').isVisible()).toBe(true);
       })
       it('should consider a summary as hidden when nested inside closed details content', () => {
         const NestedSummaryInClosedDetails = defineComponent({
@@ -265,8 +283,45 @@ describe('isVisible', () => {
             </details>
           `
         })
-
         const wrapper = mount(NestedSummaryInClosedDetails)
+        const summaries = wrapper.findAll('summary')
+
+        expect(summaries[0].isVisible()).toBe(true)
+        expect(summaries[1].isVisible()).toBe(false)
+      })
+      it('should consider a summary as visible when nested inside open details content', () => {
+        const NestedSummaryInOpenDetails = defineComponent({
+          template: `
+            <details open>
+              <summary>Main summary</summary>
+              <div>
+                <details open>
+                  <summary>Nested summary</summary>
+                </details>
+              </div>
+            </details>
+          `
+        })
+        const wrapper = mount(NestedSummaryInOpenDetails)
+        const summaries = wrapper.findAll('summary')
+
+        expect(summaries[0].isVisible()).toBe(true)
+        expect(summaries[1].isVisible()).toBe(true)
+      })
+      it('should consider a 1st summary as visible and 2nd as hidden when nested inside closed details content which is applied display: none', () => {
+        const NestedSummaryInOpenDetails = defineComponent({
+          template: `
+            <details>
+              <summary>Main summary</summary>
+              <div style="display: none;">
+                <details>
+                  <summary>Nested summary</summary>
+                </details>
+              </div>
+            </details>
+          `
+        })
+        const wrapper = mount(NestedSummaryInOpenDetails)
         const summaries = wrapper.findAll('summary')
 
         expect(summaries[0].isVisible()).toBe(true)

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -234,9 +234,44 @@ describe('isVisible', () => {
         })
 
         const wrapper = mount(DetailContent)
+        expect(wrapper.find('details').isVisible()).toBe(true)
         expect(wrapper.find('summary').isVisible()).toBe(true)
         expect(wrapper.find('div').isVisible()).toBe(false)
 
+      })
+      it('should consider a summary as hidden when an ancestor is hidden', () => {
+        const HiddenAncestorSummary = defineComponent({
+          template: `
+            <div style="display: none;">
+              <details>
+                <summary>Summary</summary>
+              </details>
+            </div>
+          `
+        })
+
+        const wrapper = mount(HiddenAncestorSummary)
+        expect(wrapper.find('summary').isVisible()).toBe(false)
+      })
+      it('should consider a summary as hidden when nested inside closed details content', () => {
+        const NestedSummaryInClosedDetails = defineComponent({
+          template: `
+            <details>
+              <summary>Main summary</summary>
+              <div>
+                <details>
+                  <summary>Nested summary</summary>
+                </details>
+              </div>
+            </details>
+          `
+        })
+
+        const wrapper = mount(NestedSummaryInClosedDetails)
+        const summaries = wrapper.findAll('summary')
+
+        expect(summaries[0].isVisible()).toBe(true)
+        expect(summaries[1].isVisible()).toBe(false)
       })
     })
   })

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -228,7 +228,7 @@ describe('isVisible', () => {
         })
         expect(wrapper.isVisible()).toBe(false)
       })
-      it ('DetailContent should be visible when summary is visible', () => {
+      it('DetailContent should be visible when summary is visible', () => {
         const DetailContent = defineComponent({
           template: `<details><summary>Summary</summary><div>Content</div></details>`
         })
@@ -237,7 +237,6 @@ describe('isVisible', () => {
         expect(wrapper.find('details').isVisible()).toBe(true)
         expect(wrapper.find('summary').isVisible()).toBe(true)
         expect(wrapper.find('div').isVisible()).toBe(false)
-
       })
       it('should consider a summary as hidden when an ancestor is hidden', () => {
         const HiddenAncestorSummary = defineComponent({

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -231,21 +231,8 @@ describe('isVisible', () => {
     })
 
     describe('details and summary elements', () => {
-      it('DetailContent should be invisible when display:none is applied by class', () => {
-        const style = document.createElement('style')
-        document.head.appendChild(style)
-        style.sheet!.insertRule('.hidden { display: none; }')
-
-        const wrapper = mount({
-          template: '<div id="my-div" class="hidden"><details><summary>Summary</summary></details></div>'
-        })
-
-        expect(wrapper.get('#my-div').isVisible()).toBe(false)
-        expect(wrapper.find('summary').isVisible()).toBe(false)
-        expect(wrapper.find('details').isVisible()).toBe(false)
-      })
       it('DetailContent should be invisible when display:none is applied by style attribute', () => {
-        const wrapper = mount({
+        const wrapper = defineComponent({
           template: '<div id="my-div" style="display: none;"><details><summary>Summary</summary></details></div>'
         })
 

--- a/tests/isVisible.spec.ts
+++ b/tests/isVisible.spec.ts
@@ -232,10 +232,12 @@ describe('isVisible', () => {
 
     describe('details and summary elements', () => {
       it('DetailContent should be invisible when display:none is applied by style attribute', () => {
-        const wrapper = defineComponent({
-          template: '<div id="my-div" style="display: none;"><details><summary>Summary</summary></details></div>'
+        const DetailContent = defineComponent({
+          template:
+            '<div id="my-div" style="display: none;"><details><summary>Summary</summary></details></div>'
         })
 
+        const wrapper = mount(DetailContent)
         expect(wrapper.get('#my-div').isVisible()).toBe(false)
         expect(wrapper.find('summary').isVisible()).toBe(false)
         expect(wrapper.find('details').isVisible()).toBe(false)
@@ -250,12 +252,12 @@ describe('isVisible', () => {
         expect(wrapper.find('summary').isVisible()).toBe(true)
         expect(wrapper.find('div').isVisible()).toBe(false)
       })
-      it ('DetailContent shouild be visible when summarys child is visible', () => {
+      it('DetailContent shouild be visible when summarys child is visible', () => {
         const childContent = defineComponent({
           template: `<details><summary><span>Summary</span></summary></details>`
         })
         const wrapper = mount(childContent)
-        expect(wrapper.find('summary span').isVisible()).toBe(true);
+        expect(wrapper.find('summary span').isVisible()).toBe(true)
       })
       it('should consider a summary as hidden when nested inside closed details content', () => {
         const NestedSummaryInClosedDetails = defineComponent({


### PR DESCRIPTION
This PR addresses https://github.com/vuejs/test-utils/issues/2626.

The issue is that <summary> element behavior is inconsistent with the real browser.

I verified this in a real browser, and the issue still occurs.

Reproduction:
https://stackblitz.com/edit/vitejs-vite-qxxwzrgz?file=src%2Fcomponents%2Ftests%2FDetailsComponent.test.ts