### PR TITLE
docs(api): note that setValue does not accept objects on <select>

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1718,6 +1718,19 @@ test('setValue on multi select', async () => {
 You should use `await` when you call `setValue` to ensure that Vue updates the DOM before you make an assertion.
 :::
 
+::: warning Object values on `<select>`
+`setValue` compares against the `<option>` element's `value` string, which is
+always a string even when the template binds an object to `v-model`. Passing
+the object itself will not match any option. Select the option by index
+instead and trigger a `change` event:
+
+```js
+const select = wrapper.find('select')
+;(select.element as HTMLSelectElement).selectedIndex = 1
+await select.trigger('change')
+```
+:::
+
 ### text
 
 Returns the text content of an element.

--- a/docs/fr/api/index.md
+++ b/docs/fr/api/index.md
@@ -1710,6 +1710,20 @@ test('setValue sur une liste déroulante à choix multiples', async () => {
 Vous devriez utiliser `await` lorsque vous appelez `setValue` pour vous assurer que Vue met à jour le DOM avant de faire une vérification.
 :::
 
+::: warning Valeurs objets sur `<select>`
+`setValue` compare la valeur passée à la chaîne `value` de l'élément
+`<option>`, qui reste une chaîne même lorsque le template lie un objet à
+`v-model`. Passer l'objet lui-même ne correspondra à aucune option.
+Sélectionnez plutôt l'option par son index puis déclenchez un événement
+`change` :
+
+```js
+const select = wrapper.find('select')
+;(select.element as HTMLSelectElement).selectedIndex = 1
+await select.trigger('change')
+```
+:::
+
 ### text
 
 Retourne le texte contenu dans un élément.

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -1711,6 +1711,18 @@ test('setValue on multi select', async () => {
 在调用 `setValue` 时，你应该使用 `await`，以确保 Vue 在你进行断言之前更新 DOM。
 :::
 
+::: warning `<select>` 上的对象值
+`setValue` 会将传入的值与 `<option>` 元素的 `value` 字符串进行比较，即使
+模板将对象绑定到 `v-model`，该值也始终是字符串。直接传入对象不会匹配
+任何选项。请改为通过索引选择选项，然后触发 `change` 事件：
+
+```js
+const select = wrapper.find('select')
+;(select.element as HTMLSelectElement).selectedIndex = 1
+await select.trigger('change')
+```
+:::
+
 ### text
 
 返回元素的文本内容。


### PR DESCRIPTION
Closes #2627

## Summary

`setValue` on a `<select>` silently does nothing when `v-model` is bound to an object, because `setValue` sets the element's `value` property (always a string) and then fires `change` — the string never matches any `<option>`'s value, so `v-model` never updates.

The maintainer pointed this out on the issue and offered two fixes: (1) document it, (2) teach `setValue` to match object-typed options the way Vue core does in `vModelSelect`. This PR does (1) — adds a warning block to the `setValue` docs that both states the limitation and gives the `selectedIndex + trigger('change')` workaround. Implementing option (2) would be a separate PR.

## Change

Single-file diff in `docs/api/index.md`: adds a new `::: warning Object values on <select>` block next to the existing `await` warning at the end of the `setValue` section.

## Testing

- Only a docs page is touched; no code, tests, or types change.
- The snippet inside the warning matches the workaround the maintainer validated in the issue thread.
