### PR TITLE
ci: add trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 # Remove default permissions of GITHUB_TOKEN for security
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Remove default permissions of GITHUB_TOKEN for security
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions: {}
+
+jobs:
+  release:
+    if: github.repository == 'vuejs/test-utils'
+    concurrency:
+      group: release
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6.0.3
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm run build
+      - run: pnpm publish --no-git-checks


### PR DESCRIPTION
this PR is part of a process to set up trusted publishing for `@vuejs/test-utils`.

I have:

- setup trusted publishing on `@vue/test-utils` on npm and disallowed publishing via tokens
- enabled release immutability
- set up a protected environment for publishes called 'npm-publish' which must be manually approved by one of 4 of us (though admins can bypass)

this means that in future, releases must follow the following pattern:
1. someone with write access can push a v* tag to `main`, which kicks off a release workflow
2. the workflow pauses until receiving an approval from a different person on a defined list (self-approval not allowed)
3. once approved, publish to npm will happen via trusted publishing

I plan to make a follow-up PR to pin the dependencies of github actions used in this workflow and in ci.yml, but for now wanted to keep things consistent between the two workflow files.