### PR TITLE
fix: tolerate duplicate attachTo cleanup

### DIFF
--- a/src/mount.ts
+++ b/src/mount.ts
@@ -100,7 +100,11 @@ export function mount(
 
     to.appendChild(el)
     app.onUnmount(() => {
-      to?.removeChild(el)
+      // The wrapper may already have been manually unmounted before auto-unmount
+      // runs, so the container can already be removed from its parent.
+      if (el.parentNode === to) {
+        to.removeChild(el)
+      }
     })
   }
   const vm = app.mount(el)

--- a/tests/autoUnmount.spec.ts
+++ b/tests/autoUnmount.spec.ts
@@ -28,6 +28,33 @@ describe('enableAutoUnmount', () => {
     expect(wrapper.unmount).toHaveBeenCalledTimes(1)
   })
 
+  it('does not throw when auto unmounting an already unmounted wrapper attached to the document', () => {
+    const hookMock = vi.fn()
+
+    enableAutoUnmount(hookMock)
+    const [unmountFn] = hookMock.mock.calls[0]
+
+    const wrapper = mount(
+      {
+        template: '<div id="attach-to-auto-unmount">test</div>'
+      },
+      {
+        attachTo: document.body
+      }
+    )
+
+    expect(document.getElementById('attach-to-auto-unmount')).not.toBeNull()
+
+    // Some test suites manually unmount a wrapper before the registered
+    // auto-unmount hook runs after the test.
+    wrapper.unmount()
+
+    expect(document.getElementById('attach-to-auto-unmount')).toBeNull()
+    // Auto-unmount still tracks the wrapper, so it must tolerate the second
+    // unmount without trying to remove an already-detached container.
+    expect(unmountFn).not.toThrow()
+  })
+
   it('cannot be called twice', () => {
     const noop = () => {}
 


### PR DESCRIPTION
Regression introduced by #2700.

Without this guard, auto-unmounting a manually unmounted wrapper attached to document.body throws `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`