### PR TITLE
fix: restore text()/html() for single-root components

### DIFF
--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -26,7 +26,10 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
   }
 
   getRootNodes() {
-    if (this.subTree?.type === Fragment && Array.isArray(this.subTree?.children)) {
+    if (
+      this.subTree?.type === Fragment &&
+      Array.isArray(this.subTree?.children)
+    ) {
       return this.subTree.children.map(node => (node as any)?.el)
     }
     return [this.wrapperElement]

--- a/src/domWrapper.ts
+++ b/src/domWrapper.ts
@@ -1,4 +1,4 @@
-import type { VNode } from 'vue'
+import { Fragment, type VNode } from 'vue'
 import { config } from './config'
 import BaseWrapper from './baseWrapper'
 import type WrapperLike from './interfaces/wrapperLike'
@@ -26,7 +26,7 @@ export class DOMWrapper<NodeType extends Node> extends BaseWrapper<NodeType> {
   }
 
   getRootNodes() {
-    if (Array.isArray(this.subTree?.children)) {
+    if (this.subTree?.type === Fragment && Array.isArray(this.subTree?.children)) {
       return this.subTree.children.map(node => (node as any)?.el)
     }
     return [this.wrapperElement]

--- a/tests/element.spec.ts
+++ b/tests/element.spec.ts
@@ -90,6 +90,22 @@ describe('element', () => {
     expect(wrapper.findComponent(Func).text()).toBe('foobar')
   })
 
+  it('text() reads DOM content for single-root components with empty vnode children', () => {
+    const Child = defineComponent({
+      render: () => h('button')
+    })
+    const Parent = defineComponent({
+      components: { Child },
+      template: '<Child/>'
+    })
+
+    const wrapper = mount(Parent)
+    const child = wrapper.findComponent(Child)
+    child.element.textContent = 'foobar'
+
+    expect(child.text()).toBe('foobar')
+  })
+
   it('returns correct element for root slot', () => {
     const Parent = defineComponent({
       components: { ReturnSlot },


### PR DESCRIPTION
Fixes a regression introduced in #2579 where `text()` / `html()` returns an empty string for single-root components whose DOM content isn't reflected in the vnode `children` array.                                    
                                                                                                                                                                                                                                                    
#2579 made `DOMWrapper.getRootNodes()` walk `subTree.children` whenever it was an array, in order to support array-returning functional components like `() => ['foo', 'bar']`. But `subTree.children` only represents "rendered roots" when `subTree` is a `Fragment`. For single-root components, `subTree` is the rendered element vnode itself and `children` represents that element's own children.                                                                                                                                                                                  
                                                                                                                                                                                                                                                    
Concrete failure: bootstrap-vue's `BButton` is a Vue 2 functional component that injects its label via `domProps: { textContent }`. Under `@vue/compat`, the rendered element has the correct `textContent`, but the vnode's `children` stays `[]`.  See https://gitlab.com/gitlab-org/gitlab-services/design.gitlab.com/-/merge_requests/5890 for the failures.

This fixes the regression by adding `subTree.type === Fragment` guard to `DOMWrapper.getRootNodes()`, so the children-walk only runs for true multi-root subtrees and single-root components fall back to the wrapper element