### PR TITLE
fix(dom-events): drop legacy Mutation Event listener entries

### DIFF
--- a/src/constants/dom-events.ts
+++ b/src/constants/dom-events.ts
@@ -305,16 +305,6 @@ const domEvents = {
     bubbles: true,
     cancelable: true
   },
-  DOMAttrModified: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
-  DOMCharacterDataModified: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
   DOMContentLoaded: {
     eventInterface: 'Event',
     bubbles: true,
@@ -335,34 +325,12 @@ const domEvents = {
     bubbles: true,
     cancelable: true
   },
-  DOMNodeInserted: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
-  DOMNodeInsertedIntoDocument: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
-  DOMNodeRemoved: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
-  DOMNodeRemovedFromDocument: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: true
-  },
-  /**
-   * @deprecated
-   */
-  DOMSubtreeModified: {
-    eventInterface: 'MutationEvent',
-    bubbles: true,
-    cancelable: false
-  },
+  // Mutation Events (DOMAttrModified, DOMCharacterDataModified, DOMNodeInserted,
+  // DOMNodeInsertedIntoDocument, DOMNodeRemoved, DOMNodeRemovedFromDocument,
+  // DOMSubtreeModified) were removed from the dispatch table because Chrome 127
+  // removed support for these legacy MutationEvents. Listening for them in the
+  // browser now logs a deprecation warning. Use MutationObserver instead.
+  // See https://chromestatus.com/feature/5083947249172480 and #2449.
   downloading: {
     eventInterface: 'Event',
     bubbles: false,


### PR DESCRIPTION
Closes #2449.

`vueWrapper` attaches one listener per key in `domEvents` so every dispatched DOM event lands in `wrapper.emitted()`. As of Chrome 127, listening for the legacy Mutation Events (per https://chromestatus.com/feature/5083947249172480) emits a deprecation warning per listener — which means VTU spams that warning in every Cypress / Vitest browser test that mounts a component (#2449 comments).

Per @cexbrayat's suggestion in the issue thread, this drops the seven removed Mutation Events from the dispatch table:

- DOMAttrModified
- DOMCharacterDataModified
- DOMNodeInserted
- DOMNodeInsertedIntoDocument
- DOMNodeRemoved
- DOMNodeRemovedFromDocument
- DOMSubtreeModified

Left in place

- `'MutationEvent'` stays in the `EventInterface` union since it is a public type and removing it is a breaking type-level change for anyone who imported it.
- The two `MutationNameEvent` entries (DOMAttributeNameChanged, DOMElementNameChanged) and the DOMFocusIn/DOMFocusOut entries were not in Chrome's removal list, so they stay.

Fallout

- Anyone calling `wrapper.emitted('DOMNodeInserted')` etc. will no longer receive the synthetic recording. Replace with `MutationObserver` (the modern equivalent) — these events have been deprecated for ~20 years and Chrome no longer fires them at all.
- A leading comment block in `dom-events.ts` documents the removal and the Chrome status link so future readers know why the entries are gone.

Verification

- `pnpm vue-tsc` clean.
- `pnpm test --run` -> 494 passed (no test referenced these events).