### PR TITLE
fix(trigger): set spec-compliant `event.code` on keydown/keyup

### DIFF
--- a/src/constants/dom-events.ts
+++ b/src/constants/dom-events.ts
@@ -91,6 +91,26 @@ export const keyCodesByKeyName = {
   delete: 46
 } as const
 
+// Maps each supported key modifier to the W3C UI Events `KeyboardEvent.code`
+// string. Keep keys aligned with `keyCodesByKeyName`.
+export const codesByKeyName = {
+  backspace: 'Backspace',
+  tab: 'Tab',
+  enter: 'Enter',
+  esc: 'Escape',
+  space: 'Space',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  end: 'End',
+  home: 'Home',
+  left: 'ArrowLeft',
+  up: 'ArrowUp',
+  right: 'ArrowRight',
+  down: 'ArrowDown',
+  insert: 'Insert',
+  delete: 'Delete'
+} as const
+
 export type KeyName = keyof typeof keyCodesByKeyName
 export type Modifier =
   | (typeof systemKeyModifiers)[number]

--- a/src/createDomEvent.ts
+++ b/src/createDomEvent.ts
@@ -6,6 +6,7 @@ import type {
 } from './constants/dom-events'
 import domEvents, {
   KeyName,
+  codesByKeyName,
   ignorableKeyModifiers,
   keyCodesByKeyName,
   mouseKeyModifiers,
@@ -113,7 +114,7 @@ function getEventProperties(eventParams: EventParams) {
     cancelable: meta.cancelable,
     // Any derived options should go here
     keyCode,
-    code: options.code || keyCode,
+    code: options.code || codesByKeyName[keyModifiers[0]] || keyCode,
     // if we have a `key`, use it, otherwise dont set anything (allows user to pass custom key)
     ...(keyModifiers[0] ? { key: keyModifiers[0] } : {})
   }
@@ -176,4 +177,10 @@ function createDOMEvent(
   return event
 }
 
-export { TriggerOptions, createDOMEvent, keyCodesByKeyName, KeyName }
+export {
+  TriggerOptions,
+  createDOMEvent,
+  codesByKeyName,
+  keyCodesByKeyName,
+  KeyName
+}

--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -3,7 +3,7 @@ import { defineComponent, h, ref } from 'vue'
 
 import { mount } from '../src'
 import type { KeyName } from '../src/createDomEvent'
-import { keyCodesByKeyName } from '../src/createDomEvent'
+import { codesByKeyName, keyCodesByKeyName } from '../src/createDomEvent'
 
 describe('trigger', () => {
   describe('on click', () => {
@@ -258,6 +258,26 @@ describe('trigger', () => {
         const currentCall = calls[calls.length - 1][0]
 
         expect(currentCall.keyCode).toBe(keyCode)
+      }
+    })
+
+    it('causes keydown handler to fire with the spec-compliant `code` string when wrapper.trigger("keydown.${keyName}") is fired', async () => {
+      const keydownHandler = vi.fn()
+
+      const Component = {
+        template: '<input @keydown="keydownHandler" />',
+        methods: { keydownHandler }
+      }
+      const wrapper = mount(Component, {})
+
+      for (const keyName in codesByKeyName) {
+        const code = codesByKeyName[keyName as KeyName]
+        await wrapper.trigger(`keydown.${keyName}`)
+
+        const calls = keydownHandler.mock.calls
+        const currentCall = calls[calls.length - 1][0]
+
+        expect(currentCall.code).toBe(code)
       }
     })
   })


### PR DESCRIPTION
Fixes [#2544](https://github.com/AhmadHannan037/test-utils/issues/2544).

trigger('keydown.enter') (and other keydown/keyup modifiers) was setting event.code to the numeric keyCode (e.g. 13) instead of the [W3C UI Events](https://www.w3.org/TR/uievents/#code-virtual-keyboards) string identifier ("Enter"). Tests checking event.code for accessibility/keyboard-navigation handlers couldn't pass because of this.

Change
Added codesByKeyName next to keyCodesByKeyName in src/constants/dom-events.ts, mapping every supported key modifier to its W3C code string.
createDomEvent.ts now picks event.code from codesByKeyName when a key modifier is present. Explicit options.code still takes priority. The numeric keyCode fallback is kept for legacy callers that pass { keyCode } without a modifier, so existing behavior is unchanged.
Coverage
Added a sibling test in tests/trigger.spec.ts (next to the existing keyCode-mapping test) that iterates codesByKeyName and asserts the handler receives the correct event.code string for every modifier.

Affected modifiers: backspace, tab, enter, esc, space, pageup, pagedown, end, home, left, up, right, down, insert, delete.