### PR TITLE
export GlobalMountOptions type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { VueWrapper } from './vueWrapper'
 import BaseWrapper from './baseWrapper'
 import { mount, shallowMount } from './mount'
 import { renderToString } from './renderToString'
-import type { MountingOptions, Stubs } from './types'
+import type { GlobalMountOptions, MountingOptions, Stubs } from './types'
 import { RouterLinkStub } from './components/RouterLinkStub'
 import { createWrapperError } from './errorWrapper'
 import { config } from './config'
@@ -26,4 +26,4 @@ export {
   createWrapperError
 }
 
-export type { MountingOptions, Stubs, ComponentMountingOptions }
+export type { GlobalMountOptions, MountingOptions, Stubs, ComponentMountingOptions }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,9 @@ export {
   createWrapperError
 }
 
-export type { GlobalMountOptions, MountingOptions, Stubs, ComponentMountingOptions }
+export type {
+  GlobalMountOptions,
+  MountingOptions,
+  Stubs,
+  ComponentMountingOptions
+}


### PR DESCRIPTION
Since version 2.4.7, the GlobalMountOptions type is not exported anymore. This type is part of [the signature of the `mount()` function](https://test-utils.vuejs.org/api/#mount).

With this change it will be exported once again.

See [this discussion thread](https://github.com/vuejs/test-utils/discussions/2849) for more information.