### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit `permissions` block to the CI workflow
- set `contents: read` for `GITHUB_TOKEN`
- keep all existing build/test steps unchanged

## Why
Declaring workflow token permissions explicitly follows least privilege and prevents unintentional privilege expansion.