### PR TITLE
chore: update Netlify Node version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,6 @@ to = "/"
 publish = "docs/.vitepress/dist"
 command = "pnpm docs:build"
 [build.environment]
-NODE_VERSION = "18"
+NODE_VERSION = "22"
 # Useful until https://github.com/nodejs/corepack/issues/612 is fixed
 COREPACK_INTEGRITY_KEYS = "0"


### PR DESCRIPTION
Updates the Netlify docs build from Node 18 to Node 22.

pnpm 11 requires Node 22+, so Netlify preview builds need to run on a supported Node version before the pnpm 11 upgrade can pass deploy-preview checks.