### PR TITLE
docs(api): update `setData` documentation to clarify data handling in options API and composition API

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1529,7 +1529,7 @@ As a rule of thumb, test against the effects of a passed prop (a DOM update, an 
 
 ### setData
 
-Updates component internal data.
+Updates component internal data, whether defined in options API `data` or composition API `setup`.
 
 **Signature:**
 
@@ -1541,22 +1541,23 @@ setData(data: Record<string, any>): Promise<void>
 
 `setData` does not allow setting new properties that are not defined in the component.
 
-::: warning
-Also, notice that `setData` does not modify composition API `setup()` data.
-:::
-
 `Component.vue`:
 
 ```vue
 <template>
-  <div>Count: {{ count }}</div>
+  <div>Size: {{ size }} {{ unit }}</div>
 </template>
 
 <script>
 export default {
+  setup() {
+    return {
+      size: ref(0)
+    }
+  },
   data() {
     return {
-      count: 0
+      unit: 'cm'
     }
   }
 }
@@ -1571,11 +1572,11 @@ import Component from './Component.vue'
 
 test('setData', async () => {
   const wrapper = mount(Component)
-  expect(wrapper.html()).toContain('Count: 0')
+  expect(wrapper.html()).toContain('Size: 0 cm')
 
-  await wrapper.setData({ count: 1 })
+  await wrapper.setData({ size: 1, unit: 'mm' })
 
-  expect(wrapper.html()).toContain('Count: 1')
+  expect(wrapper.html()).toContain('Size: 1 mm')
 })
 ```
 

--- a/docs/fr/api/index.md
+++ b/docs/fr/api/index.md
@@ -1523,7 +1523,7 @@ En règle générale, testez les effets d'une `prop` transmise (une mise à jour
 
 ### setData
 
-Met à jour les données internes d'un composant.
+Met à jour les données internes d'un composant, qu'elles soient définies dans l'API d'options `data` ou dans l'API de composition `setup`.
 
 **Signature&nbsp;:**
 
@@ -1535,23 +1535,26 @@ setData(data: Record<string, any>): Promise<void>
 
 `setData` ne permet pas de définir de nouvelles propriétés qui ne sont pas définies dans le composant.
 
-De plus, notez que `setData` ne modifie pas les données de la fonction l'API de Composition&nbsp;: `setup()`.
-
 `Component.vue`:
 
 ```vue
 <template>
-  <div>Compteur: {{ count }}</div>
+  <div>Taille: {{ size }} {{ unit }}</div>
 </template>
 
 <script>
 export default {
+  setup() {
+    return {
+      size: ref(0)
+    }
+  },
   data() {
     return {
-      count: 0,
-    };
-  },
-};
+      unit: 'cm'
+    }
+  }
+}
 </script>
 ```
 
@@ -1563,11 +1566,11 @@ import Component from './Component.vue';
 
 test('setData', async () => {
   const wrapper = mount(Component);
-  expect(wrapper.html()).toContain('Compteur: 0');
+  expect(wrapper.html()).toContain('Taille: 0 cm')
 
-  await wrapper.setData({ count: 1 });
+  await wrapper.setData({ size: 1, unit: 'mm' })
 
-  expect(wrapper.html()).toContain('Compteur: 1');
+  expect(wrapper.html()).toContain('Taille: 1 mm')
 });
 ```
 

--- a/docs/zh/api/index.md
+++ b/docs/zh/api/index.md
@@ -1522,7 +1522,7 @@ test('props', () => {
 
 ### setData
 
-更新组件内部数据。
+更新组件内部数，无论是在选项 API `data` 中定义还是在组合 API `setup` 中定义。
 
 **签名：**
 
@@ -1534,22 +1534,23 @@ setData(data: Record<string, any>): Promise<void>
 
 `setData` 不允许设置组件中未定义的新属性。
 
-::: warning
-请注意，`setData` 不会修改组合式 API 中 setup() 的数据。
-:::
-
 `Component.vue`:
 
 ```vue
 <template>
-  <div>Count: {{ count }}</div>
+  <div>Size: {{ size }} {{ unit }}</div>
 </template>
 
 <script>
 export default {
+  setup() {
+    return {
+      size: ref(0)
+    }
+  },
   data() {
     return {
-      count: 0
+      unit: 'cm'
     }
   }
 }
@@ -1564,11 +1565,11 @@ import Component from './Component.vue'
 
 test('setData', async () => {
   const wrapper = mount(Component)
-  expect(wrapper.html()).toContain('Count: 0')
+  expect(wrapper.html()).toContain('Size: 0 cm')
 
-  await wrapper.setData({ count: 1 })
+  await wrapper.setData({ size: 1, unit: 'mm' })
 
-  expect(wrapper.html()).toContain('Count: 1')
+  expect(wrapper.html()).toContain('Size: 1 mm')
 })
 ```
 


### PR DESCRIPTION
Follow-up to https://github.com/vuejs/test-utils/pull/2655

Updated the example based on the tests added in https://github.com/vuejs/test-utils/pull/2846

I've done the French and Chinese docs with the help of Google translate