### PR TITLE
fix(#2675): keep re-rendering root component after another wrapper is mounted

### DIFF
--- a/src/vnodeTransformers/util.ts
+++ b/src/vnodeTransformers/util.ts
@@ -29,6 +29,21 @@ export interface RootComponents {
   // If component is functional then contains the original component otherwise empty
   functional?: Component
 }
+// `transformVNodeArgs` is a global, last-call-wins Vue API, so when several
+// wrappers are mounted the active transformer only knows about the most
+// recently mounted root component. Track every mounted root component globally
+// so that re-rendering an earlier wrapper (e.g. via `setProps`) doesn't stub
+// its root just because another wrapper was mounted afterwards.
+// See https://github.com/vuejs/test-utils/issues/2675
+const mountedRootComponents = new WeakSet<object>()
+const registerRootComponent = (type?: Component): void => {
+  // WeakSet keys must be objects/functions; component definitions always are,
+  // but `Component` also allows a string name which we simply ignore.
+  if (type && typeof type !== 'string') {
+    mountedRootComponents.add(type)
+  }
+}
+
 export const isRootComponent = (
   rootComponents: RootComponents,
   type: VNodeTransformerInputComponentType,
@@ -37,7 +52,9 @@ export const isRootComponent = (
   !!(
     !instance ||
     // Don't stub mounted component on root level
-    (rootComponents.component === type && !instance?.parent) ||
+    ((rootComponents.component === type ||
+      mountedRootComponents.has(type as object)) &&
+      !instance?.parent) ||
     // Don't stub component with compat wrapper
     (rootComponents.functional && rootComponents.functional === type)
   )
@@ -53,6 +70,9 @@ export const createVNodeTransformer = ({
     VNodeTransformerInputComponentType,
     VNodeTransformerInputComponentType
   > = new WeakMap()
+
+  registerRootComponent(rootComponents.component)
+  registerRootComponent(rootComponents.functional)
 
   return (args: VNodeTransformerArgsType, instance: InstanceArgsType) => {
     const [originalType, props, children, ...restVNodeArgs] = args

--- a/tests/shallowMount.spec.ts
+++ b/tests/shallowMount.spec.ts
@@ -100,6 +100,26 @@ describe('shallowMount', () => {
     expect(wrapper.find('h2').text()).toBe('3')
   })
 
+  // https://github.com/vuejs/test-utils/issues/2675
+  it('keeps re-rendering a root component after another wrapper is mounted', async () => {
+    const ComponentA = defineComponent({
+      props: { msg: { type: String, default: '' } },
+      template: '<div>{{ msg }}</div>'
+    })
+    const ComponentB = defineComponent({ template: '<div>B</div>' })
+
+    const wrapper = shallowMount(ComponentA, { props: { msg: 'initial' } })
+
+    // Mounting another wrapper installs a new global vnode transformer; the
+    // first wrapper's root must still re-render on setProps rather than being
+    // stubbed.
+    shallowMount(ComponentB)
+
+    await wrapper.setProps({ msg: 'updated' })
+
+    expect(wrapper.text()).toBe('updated')
+  })
+
   it('correctly renders slot content', () => {
     const ComponentWithSlot = defineComponent({
       template: '<div><slot></slot></div>'


### PR DESCRIPTION
Closes #2675

`shallowMount`/`mount` install a vnode transformer via Vue's global `transformVNodeArgs`, which is last-call-wins: mounting a second wrapper replaces the first wrapper's transformer. That transformer only treats *its own* root component as "don't stub", so when an earlier wrapper later re-renders (e.g. via `setProps`), its root no longer matches and gets stubbed. The DOM keeps the old output and `setProps` looks like it does nothing.

That's why the issue only appears when a wrapper declared outside the test is reused across several tests, and mostly with `shallowMount`, where stubbing is active.

The fix tracks every mounted root component in a module-level `WeakSet` and treats any of them as a root in `isRootComponent`. It stays gated by `!instance.parent`, so genuine child components are still stubbed as before. Only a re-rendered root is spared.

Added a `shallowMount` test that mounts a second wrapper and then calls `setProps` on the first one. It fails on `main` (renders `initial`) and passes with this change (renders `updated`).
