### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/fr/installation/index.md
+++ b/docs/fr/installation/index.md
@@ -10,6 +10,10 @@ npm install --save-dev @vue/test-utils
 yarn add --dev @vue/test-utils
 ```
 
+```shell [deno]
+deno install --dev @vue/test-utils
+```
+
 :::
 
 ## Utilisation

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -10,6 +10,10 @@ npm install --save-dev @vue/test-utils
 yarn add --dev @vue/test-utils
 ```
 
+```shell [deno]
+deno install --dev @vue/test-utils
+```
+
 :::
 
 ## Usage

--- a/docs/zh/installation/index.md
+++ b/docs/zh/installation/index.md
@@ -10,6 +10,10 @@ npm install --save-dev @vue/test-utils
 yarn add --dev @vue/test-utils
 ```
 
+```shell [deno]
+deno install --dev @vue/test-utils
+```
+
 :::
 
 ## 用法


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm and yarn, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install --dev @vue/test-utils
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install @vue/test-utils`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
