### PR TITLE
fix: stub globally registered components by alias

### DIFF
--- a/src/utils/componentName.ts
+++ b/src/utils/componentName.ts
@@ -28,6 +28,14 @@ export const getComponentRegisteredName = (
     }
   }
 
+  // try to infer the name based on global resolution
+  const globalRegistry = instance.appContext.components
+  for (const key in globalRegistry) {
+    if (globalRegistry[key] === type) {
+      return key
+    }
+  }
+
   // try to retrieve name imported in script setup
   return getComponentNameInSetup(instance.parent, type) || null
 }

--- a/tests/mountingOptions/global.stubs.spec.ts
+++ b/tests/mountingOptions/global.stubs.spec.ts
@@ -367,6 +367,36 @@ describe('mounting options: stubs', () => {
     expect(wrapper.html()).toBe('<foo-bar-stub></foo-bar-stub>')
   })
 
+  it('stubs a globally registered component by its registration name', () => {
+    const LibraryComponent = defineComponent({
+      name: 'LibraryInternalName',
+      template: '<span>real library component</span>'
+    })
+
+    const Plugin = {
+      install(app: any) {
+        app.component('GlobalAlias', LibraryComponent)
+      }
+    }
+
+    const Component = defineComponent({
+      template: '<div><GlobalAlias /></div>'
+    })
+
+    const wrapper = mount(Component, {
+      global: {
+        plugins: [Plugin],
+        stubs: {
+          GlobalAlias: true
+        }
+      }
+    })
+
+    expect(wrapper.html()).toBe(
+      '<div>\n' + '  <global-alias-stub></global-alias-stub>\n' + '</div>'
+    )
+  })
+
   it('stubs components within script setup', () => {
     const wrapper = mount(ScriptSetupWithChildren as any, {
       global: {


### PR DESCRIPTION
﻿## Summary

- resolve component registration names from the app-level component registry when matching `global.stubs`
- keep local component registration names as the first priority, then fall back to global registrations and existing script setup/name inference
- add a regression test for components registered by a plugin under a public alias that differs from the component's internal name

## Root Cause

`getComponentRegisteredName()` only inspected the parent component's local `components` option. Components installed through plugins or libraries with `app.component('GlobalAlias', Component)` were resolved by Vue at runtime, but Vue Test Utils could only see the component's internal `name`. As a result, `global.stubs.GlobalAlias` did not match unless the internal component name happened to be the same.

Fixes #2541.

## Validation

- `pnpm test tests/mountingOptions/global.stubs.spec.ts -t "globally registered component by its registration name" --run`
- `pnpm test tests/mountingOptions/global.stubs.spec.ts --run`
- `pnpm test tests/mountingOptions/global.components.spec.ts --run`
- `pnpm test --run`
- `pnpm run lint`
- `pnpm run vue-tsc`
- `pnpm exec oxfmt --check src/utils/componentName.ts tests/mountingOptions/global.stubs.spec.ts`