### PR TITLE
fix: clear emitted event history for child components on unmount

### DIFF
--- a/src/emit.ts
+++ b/src/emit.ts
@@ -13,6 +13,7 @@ const enum DevtoolsHooks {
 }
 
 const events: Events = {}
+const recordedUidsByRoot = new Map<number, Set<number>>()
 
 export function emitted<T = unknown>(
   vm: ComponentPublicInstance,
@@ -75,6 +76,13 @@ export const recordEvent = (
   while (typeof wrapperVm?.type === 'function') wrapperVm = wrapperVm.parent!
 
   const cid = wrapperVm.uid
+  const rootCid = wrapperVm.root.uid
+
+  if (!recordedUidsByRoot.has(rootCid)) {
+    recordedUidsByRoot.set(rootCid, new Set())
+  }
+  recordedUidsByRoot.get(rootCid)!.add(cid)
+
   if (!(cid in events)) {
     events[cid] = {}
   }
@@ -87,6 +95,12 @@ export const recordEvent = (
 }
 
 export const removeEventHistory = (vm: ComponentPublicInstance): void => {
-  const cid = vm.$.uid
-  delete events[cid]
+  const rootCid = vm.$.root.uid
+  const uids = recordedUidsByRoot.get(rootCid)
+  if (!uids) return
+
+  for (const uid of uids) {
+    delete events[uid]
+  }
+  recordedUidsByRoot.delete(rootCid)
 }

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -381,4 +381,59 @@ describe('emitted', () => {
     wrapper1.unmount()
     wrapper2.unmount()
   })
+
+  it('clears emitted event history of child components on unmount', async () => {
+    const Child = defineComponent({
+      name: 'Child',
+      emits: ['foo'],
+      setup(_, { emit }) {
+        emit('foo', 'bar')
+        return () => h('div', 'child')
+      }
+    })
+    const Parent = defineComponent({
+      name: 'Parent',
+      render: () => h(Child)
+    })
+
+    const wrapper = mount(Parent)
+    const child = wrapper.findComponent(Child)
+    expect(child.emitted('foo')).toHaveLength(1)
+
+    wrapper.unmount()
+
+    // the child's history must be removed too, not only the root's
+    expect(child.emitted('foo')).toBeUndefined()
+  })
+
+  it('clears history of a child removed before the root is unmounted', async () => {
+    const Child = defineComponent({
+      name: 'Child',
+      emits: ['foo'],
+      setup(_, { emit }) {
+        emit('foo', 'bar')
+        return () => h('div', 'child')
+      }
+    })
+    const Parent = defineComponent({
+      name: 'Parent',
+      props: { show: { type: Boolean, default: true } },
+      setup(props) {
+        return () => (props.show ? h(Child) : h('div', 'empty'))
+      }
+    })
+
+    const wrapper = mount(Parent)
+    const child = wrapper.findComponent(Child)
+    expect(child.emitted('foo')).toHaveLength(1)
+
+    // remove the child before the root unmounts (v-if style). Its uid is now unreachable from the root's render tree, but its history is still stored.
+    await wrapper.setProps({ show: false })
+    expect(wrapper.findComponent(Child).exists()).toBe(false)
+    expect(child.emitted('foo')).toHaveLength(1)
+
+    wrapper.unmount()
+
+    expect(child.emitted('foo')).toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary

`removeEventHistory` cleared only the root component's entry from the module-level `events` map in `src/emit.ts`, so emit histories recorded under descendant components' uids were never removed on `wrapper.unmount()`.

`recordEvent` writes under the uid of every component that emits: the devtools `component:emit` hook is global, and `attachNativeEventListener` records native DOM events against each wrapper (including child wrappers from `findComponent`). Native DOM `Event` payloads keep `event.target` and its DOM subtree reachable. With Vitest `isolate: false` the `events` map is shared across files, so these entries accumulate.

This walks the component tree on unmount and removes every component instance's entry.

Fixes #2897

## Notes
- `aggregateChildren` / `nodesAsObject` are duplicated from `src/utils/find.ts` to avoid coupling this path to the selector code; happy to extract a shared util if preferred.
- Components unmounted earlier in a test (e.g. via `v-if`) are not reachable from the tree at root-unmount time. A `WeakMap`-keyed store would also cover that and could be a follow-up.