### PR TITLE
chore: add actionlint with ShellCheck for workflow linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,7 +6,7 @@ self-hosted-runner:
 # ShellCheck rules disabled inside run: blocks.
 # Each `run:` block is checked through ShellCheck; suppress noisy rules here.
 paths:
-  ".github/workflows/**/*.{yml,yaml}":
+  '.github/workflows/**/*.{yml,yaml}':
     ignore:
       - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
       - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,7 +8,7 @@ self-hosted-runner:
 paths:
   '.github/workflows/**/*.{yml,yaml}':
     ignore:
-      - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
-      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
-      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
-      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values
+      - 'shellcheck reported issue in this script: SC1091:.+' # Can't follow non-constant source
+      - 'shellcheck reported issue in this script: SC2086:.+' # Double-quote to prevent globbing/word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+' # Consider using { cmd1; cmd2; } >> file
+      - 'shellcheck reported issue in this script: SC2155:.+' # Declare and assign separately to avoid masking return values

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+self-hosted-runner:
+  labels: []
+
+# ShellCheck rules disabled inside run: blocks.
+# Each `run:` block is checked through ShellCheck; suppress noisy rules here.
+paths:
+  ".github/workflows/**/*.{yml,yaml}":
+    ignore:
+      - 'shellcheck reported issue in this script: SC1091:.+'  # Can't follow non-constant source
+      - 'shellcheck reported issue in this script: SC2086:.+'  # Double-quote to prevent globbing/word splitting
+      - 'shellcheck reported issue in this script: SC2129:.+'  # Consider using { cmd1; cmd2; } >> file
+      - 'shellcheck reported issue in this script: SC2155:.+'  # Declare and assign separately to avoid masking return values

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,34 @@
+name: Actionlint
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actionlint.yaml'
+      - '.github/actionlint.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download actionlint
+        id: download
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Run actionlint
+        run: |
+          ./actionlint -color
+        shell: bash


### PR DESCRIPTION
Adds [actionlint](https://github.com/rhysd/actionlint) to catch GitHub Actions workflow issues — schema errors, invalid expression contexts, and shell bugs in `run:` blocks via ShellCheck.

**What's added:**

- `.github/actionlint.yaml` — actionlint config that suppresses four ShellCheck rules that are known false positives in GitHub Actions `run:` blocks (`SC2086`, `SC2129`, `SC2155`, `SC1091`)
- `.github/workflows/actionlint.yml` — a dedicated workflow that runs actionlint on any push or PR that touches `.github/workflows/**`

The repo already has three workflow files (`ci.yml`, `release.yml`, `release-nightly.yml`) but no linting for them. This closes that gap with zero blast radius — two new files, no changes to existing ones.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
