### PR TITLE
fix: trigger button click from keyboard activation

### DIFF
--- a/src/baseWrapper.ts
+++ b/src/baseWrapper.ts
@@ -33,6 +33,31 @@ import { stringifyNode } from './utils/stringifyNode'
 import type { HTMLBeautifyOptions } from 'js-beautify'
 import beautify from 'js-beautify'
 
+function isKeyboardClickActivation(
+  element: Node,
+  event: Event & TriggerOptions
+) {
+  if (
+    !isElement(element) ||
+    !(element instanceof HTMLButtonElement) ||
+    event.type !== 'keydown'
+  ) {
+    return false
+  }
+
+  const key = typeof event.key === 'string' ? event.key.toLowerCase() : ''
+
+  return (
+    key === 'enter' ||
+    key === ' ' ||
+    key === 'space' ||
+    event.code === 'Enter' ||
+    event.code === 'Space' ||
+    event.keyCode === 13 ||
+    event.keyCode === 32
+  )
+}
+
 export default abstract class BaseWrapper<
   ElementType extends Node
 > implements WrapperLike {
@@ -387,7 +412,13 @@ export default abstract class BaseWrapper<
       // we workaround this issue by manually setting _vts to Date.now() + 1
       // thus making sure the event handler is invoked
       event._vts = Date.now() + 1
-      this.element.dispatchEvent(event)
+      const eventNotCanceled = this.element.dispatchEvent(event)
+
+      if (eventNotCanceled && isKeyboardClickActivation(this.element, event)) {
+        const clickEvent = createDOMEvent('click')
+        clickEvent._vts = Date.now() + 1
+        this.element.dispatchEvent(clickEvent)
+      }
     }
 
     return nextTick()

--- a/tests/trigger.spec.ts
+++ b/tests/trigger.spec.ts
@@ -280,6 +280,33 @@ describe('trigger', () => {
         expect(currentCall.code).toBe(code)
       }
     })
+
+    it('triggers click activation for enter and space on buttons', async () => {
+      const clickHandler = vi.fn<() => void>()
+      const Component = {
+        template: '<button @click="clickHandler" />',
+        methods: { clickHandler }
+      }
+      const wrapper = mount(Component)
+
+      await wrapper.trigger('keydown.enter')
+      await wrapper.trigger('keydown.space')
+
+      expect(clickHandler).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not trigger click activation when button keydown is prevented', async () => {
+      const clickHandler = vi.fn<() => void>()
+      const Component = {
+        template: '<button @keydown.prevent @click="clickHandler" />',
+        methods: { clickHandler }
+      }
+      const wrapper = mount(Component)
+
+      await wrapper.trigger('keydown.enter')
+
+      expect(clickHandler).not.toHaveBeenCalled()
+    })
   })
 
   describe('on disabled elements', () => {


### PR DESCRIPTION
### Description

Fixes #2545.

`wrapper.trigger('keydown.enter')` and `wrapper.trigger('keydown.space')` now synthesize the browser-style click activation for enabled `<button>` elements. The synthesized click is only dispatched if the keydown event is not canceled, so handlers using `.prevent` can suppress activation like they do in the browser.

### Validation

- `corepack pnpm vitest run tests/trigger.spec.ts`
- `corepack pnpm exec oxfmt --check src/baseWrapper.ts tests/trigger.spec.ts`
- `corepack pnpm exec oxlint src/baseWrapper.ts tests/trigger.spec.ts` (exits 0; existing warning-only findings remain in the file)
- `corepack pnpm run build`
- `git diff --check`
