### PR TITLE
fix(#2591): expose defineExpose bindings on findComponent vm

### DIFF
--- a/src/vueWrapper.ts
+++ b/src/vueWrapper.ts
@@ -1,5 +1,5 @@
 import type { App, ComponentPublicInstance, VNode } from 'vue'
-import { nextTick, proxyRefs } from 'vue'
+import { nextTick, proxyRefs, unref } from 'vue'
 
 import { config } from './config'
 import domEvents from './constants/dom-events'
@@ -27,19 +27,26 @@ function createVMProxy<T extends ComponentPublicInstance>(
 ): T {
   return new Proxy(vm, {
     get(vm, key, receiver) {
-      if (vm.$.exposed && vm.$.exposeProxy && key in vm.$.exposeProxy) {
-        // first if the key is exposed
+      if (vm.$.exposeProxy && key in vm.$.exposeProxy) {
+        // first if the key is exposed in exposeProxy
         return Reflect.get(vm.$.exposeProxy, key, receiver)
+      } else if (vm.$.exposed && key in vm.$.exposed) {
+        // Vue only creates exposeProxy lazily (template ref or directive),
+        // so a component can expose an API while exposeProxy is still null.
+        // See https://github.com/vuejs/test-utils/issues/2591
+        return unref(Reflect.get(vm.$.exposed, key, receiver))
       } else if (key in setupState) {
-        // second if the key is acccessible from the setupState
+        // third if the key is acccessible from the setupState
         return Reflect.get(setupState, key, receiver)
       } else if (key in vm.$.appContext.config.globalProperties) {
-        // third if the key is a global property
+        // fourth if the key is a global property
         return Reflect.get(
           vm.$.appContext.config.globalProperties,
           key,
           receiver
         )
+      } else if (key in vm) {
+        return Reflect.get(vm, key)
       } else {
         // vm.$.ctx is the internal context of the vm
         // with all variables, methods and props
@@ -108,9 +115,13 @@ export class VueWrapper<
     // if we return it as `vm`
     // This does not work for functional components though (as they have no vm)
     // or for components with a setup that returns a render function (as they have an empty proxy)
-    // in both cases, we return `vm` directly instead
+    // in both cases, we return `vm` directly instead — unless the component
+    // used expose()/defineExpose(), so findComponent() can still read those
+    // properties when Vue has not created exposeProxy (issue #2591)
     if (hasSetupState(vm)) {
       this.componentVM = createVMProxy<T>(vm, vm.$.setupState)
+    } else if (vm?.$?.exposed) {
+      this.componentVM = createVMProxy<T>(vm, {})
     } else {
       this.componentVM = vm
     }

--- a/tests/expose.spec.ts
+++ b/tests/expose.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { defineComponent, h, nextTick, ref } from 'vue'
 import { mount } from '../src'
 
 import DefineExpose from './components/DefineExpose.vue'
@@ -154,5 +154,123 @@ describe('expose', () => {
 
     expect(spiedIncrement).toHaveBeenCalled()
     expect(wrapper.html()).toContain('-1')
+  })
+
+  it('access exposed vm properties via findComponent on a bundled-style component', () => {
+    // Vite-bundled <script setup> compiles to setup() + expose() + a returned
+    // render function. Vue does not create exposeProxy unless the child is
+    // referenced via a template ref or uses a directive.
+    // https://github.com/vuejs/test-utils/issues/2591
+    const VExample = defineComponent({
+      name: 'VExample',
+      props: {
+        a: String
+      },
+      setup(props, { expose }) {
+        const exposedRef = ref('exposedRef')
+        const exposedFn = () => 'hey'
+        expose({
+          exposedFn,
+          exposedRef
+        })
+        return () => h('div', 'Example')
+      }
+    })
+
+    const wrapper = mount({
+      components: { VExample },
+      template: `<div><v-example /></div>`
+    })
+
+    const child = wrapper.findComponent({ name: 'VExample' })
+
+    expect(child.exists()).toBe(true)
+    expect(child.vm.exposedFn).toBeInstanceOf(Function)
+    expect(child.vm.exposedFn()).toBe('hey')
+    expect(child.vm.exposedRef).toBe('exposedRef')
+  })
+
+  describe('when exposeProxy is null', () => {
+    const nullifyExposeProxy = (vm: any) => {
+      vm.$.exposeProxy = null
+    }
+
+    it('access vm on simple components with custom `expose`', async () => {
+      const wrapper = mount(DefineExpose)
+      const vm = wrapper.vm
+
+      nullifyExposeProxy(vm)
+      commonTests(vm)
+
+      // returned state shuold be accessible
+      expect(vm.returnedState).toBe('returnedState')
+
+      // non-exposed and non-returned state should not be accessible
+      expect(
+        (vm as unknown as { stateNonExposedAndNonReturned: undefined })
+          .stateNonExposedAndNonReturned
+      ).toBe(undefined)
+    })
+
+    it('access vm on simple components with custom `expose` and a setup returning a render function', async () => {
+      const wrapper = mount(DefineExposeWithRenderFunction)
+      const vm = wrapper.vm
+
+      nullifyExposeProxy(vm)
+      commonTests(vm)
+
+      // can't access `refUseByRenderFnButNotExposed` as it is not exposed
+      // and we are in a component with a setup returning a render function
+      expect(
+        (vm as unknown as { refUseByRenderFnButNotExposed: undefined })
+          .refUseByRenderFnButNotExposed
+      ).toBeUndefined()
+    })
+
+    it('access vm with <script setup> and defineExpose()', async () => {
+      const wrapper = mount(ScriptSetupExpose)
+      const vm = wrapper.vm as unknown as {
+        inc: () => void
+        resetCount: () => void
+        count: number
+        refNonExposed: string
+        refNonExposedGetter: () => string
+      }
+
+      nullifyExposeProxy(vm)
+      commonTests(vm)
+
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.html()).toContain('1')
+
+      // can access state/method/ref as it is exposed via `defineExpose()`
+      expect(vm.count).toBe(1)
+      vm.resetCount()
+      expect(vm.count).toBe(0)
+
+      // non-exposed state/method/ref should be accessible
+      vm.inc()
+      expect(vm.count).toBe(1)
+      expect(vm.refNonExposed).toBe('refNonExposed')
+      vm.refNonExposed = 'newRefNonExposed'
+      expect(vm.refNonExposedGetter()).toBe('newRefNonExposed')
+    })
+
+    it('access vm with <script setup> even without defineExpose()', async () => {
+      const wrapper = mount(ScriptSetup)
+
+      nullifyExposeProxy(wrapper.vm)
+
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.html()).toContain('1')
+      // can access `count` even if it is _not_ exposed
+      // @ts-expect-error we need better types here, see https://github.com/vuejs/test-utils/issues/972
+      expect(wrapper.vm.count).toBe(1)
+
+      // @ts-expect-error we need better types here, see https://github.com/vuejs/test-utils/issues/972
+      wrapper.vm.count = 2
+      await nextTick()
+      expect(wrapper.html()).toContain('2')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- `findComponent()` now returns `defineExpose()` / `expose()` bindings on `vm` for bundled-style components (setup that returns a render function). Vue only creates `exposeProxy` lazily (template ref or directive), so a child can have an exposed API while `exposeProxy` is still `null`.
- Also wrap those instances in the vm proxy when `devtoolsRawSetupState` is missing, which is the typical bundled `<script setup>` case.
- Adds a reproduction for #2591 plus coverage for `exposeProxy === null`.

This supersedes #2715.

Fixes #2591

## Test plan
- [x] `pnpm test` — includes bundled-style `findComponent` case and null-`exposeProxy` cases
- [x] `pnpm run lint` / `format-check` / `test:build` / `tsd` / `vue-tsc` / `tsc:docs`


Made with [Cursor](https://cursor.com)