### PR TITLE
fix: share config across builds

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,9 @@ class Pluggable<Instance = DOMWrapper<Node>> {
   }
 }
 
+// Different builds of Vue Test Utils can be loaded in the same JavaScript
+// realm. Store config under a versioned global symbol so those builds share
+// state without sharing it across incompatible major versions.
 const configKey = Symbol.for('@vue/test-utils:config:v2')
 
 function createConfig(): GlobalConfigOptions {

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,23 +65,33 @@ class Pluggable<Instance = DOMWrapper<Node>> {
   }
 }
 
-export const config: GlobalConfigOptions = {
-  global: {
-    stubs: {
-      transition: true,
-      'transition-group': true
+const configKey = Symbol.for('@vue/test-utils:config:v2')
+
+function createConfig(): GlobalConfigOptions {
+  return {
+    global: {
+      stubs: {
+        transition: true,
+        'transition-group': true
+      },
+      provide: {},
+      components: {},
+      config: {},
+      directives: {},
+      mixins: [],
+      mocks: {},
+      plugins: [],
+      renderStubDefaultSlot: false
     },
-    provide: {},
-    components: {},
-    config: {},
-    directives: {},
-    mixins: [],
-    mocks: {},
-    plugins: [],
-    renderStubDefaultSlot: false
-  },
-  plugins: {
-    VueWrapper: new Pluggable(),
-    DOMWrapper: new Pluggable()
+    plugins: {
+      VueWrapper: new Pluggable(),
+      DOMWrapper: new Pluggable()
+    }
   }
 }
+
+const sharedState = globalThis as Record<PropertyKey, unknown>
+
+export const config: GlobalConfigOptions =
+  (sharedState[configKey] as GlobalConfigOptions | undefined) ??
+  (sharedState[configKey] = createConfig())

--- a/tests/config.spec.ts
+++ b/tests/config.spec.ts
@@ -5,7 +5,7 @@ import type {
   ComponentCustomProperties,
   ComponentPublicInstance
 } from 'vue'
-import { config, mount } from '../src'
+import { type VueWrapper, config, mount } from '../src'
 import Hello from './components/Hello.vue'
 import ComponentWithSlots from './components/ComponentWithSlots.vue'
 import type { Router } from 'vue-router'
@@ -25,6 +25,30 @@ describe('config', () => {
     }
 
     vi.clearAllMocks()
+  })
+
+  it('is shared across module evaluations', async () => {
+    const marker = {}
+    const originalMocks = config.global.mocks
+    const originalPlugins = [...config.plugins.VueWrapper.installedPlugins]
+
+    try {
+      config.global.mocks = { marker }
+      config.plugins.VueWrapper.install(() => ({ marker }))
+
+      vi.resetModules()
+      const { config: reloadedConfig } = await import('../src/config')
+      const wrapper = {} as VueWrapper
+
+      reloadedConfig.plugins.VueWrapper.extend(wrapper)
+
+      expect(reloadedConfig).toBe(config)
+      expect(reloadedConfig.global.mocks.marker).toBe(marker)
+      expect(wrapper).toHaveProperty('marker', marker)
+    } finally {
+      config.global.mocks = originalMocks
+      config.plugins.VueWrapper.installedPlugins = originalPlugins
+    }
   })
 
   describe('config merger', () => {


### PR DESCRIPTION
Vue Test Utils’ CJS and ESM builds could create separate configuration objects in the same JavaScript realm, causing changes made through one build to be invisible to another. Sharing the configuration through a versioned global symbol ensures all builds use the same state, fixing integrations such as vue-router-mock in Vitest Browser Mode without requiring consumer workarounds.